### PR TITLE
Persist event in onChange handler

### DIFF
--- a/lib/number_format.js
+++ b/lib/number_format.js
@@ -135,7 +135,7 @@ var NumberFormat = React.createClass({
     this.setState({ value: formattedValue }, function () {
       cursorPos = _this.getCursorPosition(inputValue, formattedValue, cursorPos);
       _this.setCaretPosition(cursorPos);
-      if (callback) callback(e, value);
+      if (callback) callback(e.persist(), value);
     });
 
     return value;


### PR DESCRIPTION
Accessing the Event asynchronously doesn't work since React 0.14. This fixes this Warning:

```
Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the property `target` on a released/nullified synthetic event. This is set to null. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.
```