### PR TITLE
Fix decimalPrecision with custom decimalSeparator

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -27,7 +27,7 @@ class App extends React.Component {
       <div>
         <div className="example">
           <h3>
-            Prefix and thousand seperator : Format currency as text
+            Prefix and thousand separator : Format currency as text
           </h3>
           <NumberFormat value={2456981} displayType={'text'} thousandSeparator={true} prefix={'$'} />
         </div>
@@ -41,7 +41,7 @@ class App extends React.Component {
 
         <div className="example">
           <h3>
-            Prefix and thousand seperator : Format currency in input
+            Prefix and thousand separator : Format currency in input
           </h3>
           <NumberFormat thousandSeparator={true} value={this.state.test} prefix={'$'} onChange={(e, val) => this.setState({test: val})} />
         </div>
@@ -56,20 +56,39 @@ class App extends React.Component {
 
         <div className="example">
           <h3>
-            Custom thousand seperator : Format currency in input
+            Custom thousand separator : Format currency in input
           </h3>
           <div>
             ThousandSeperator: '.', decimalSeparator=','
           </div>
           <div>
-            <NumberFormat thousandSeparator={"."} decimalSeparator={','} prefix={'$'} />
+            <NumberFormat thousandSeparator={"."} decimalSeparator={","} prefix={"$"} />
           </div>
           <br/>
           <div>
             ThousandSeperator: ' ', decimalSeparator='.'
           </div>
           <div>
-            <NumberFormat thousandSeparator={" "} decimalSeparator={'.'} prefix={'$'} />
+            <NumberFormat thousandSeparator={" "} decimalSeparator={"."} prefix={"$"} />
+          </div>
+        </div>
+
+        <div className="example">
+          <h3>
+            Custom thousand separator with decimal precision
+          </h3>
+          <div>
+            ThousandSeperator: ',', decimalSeparator='.', decimalPrecision:2
+          </div>
+          <div>
+            <NumberFormat thousandSeparator={","} decimalSeparator={"."} decimalPrecision={2} />
+          </div>
+          <br/>
+          <div>
+            ThousandSeperator: '.', decimalSeparator=',', decimalPrecision:2
+          </div>
+          <div>
+            <NumberFormat thousandSeparator={"."} decimalSeparator={","} decimalPrecision={2} />
           </div>
         </div>
 

--- a/lib/number_format.js
+++ b/lib/number_format.js
@@ -190,7 +190,15 @@ var NumberFormat = function (_React$Component) {
           var parts = void 0;
           if (decimalPrecision !== false) {
             var precision = decimalPrecision === true ? 2 : decimalPrecision;
-            parts = parseFloat(formattedValue).toFixed(precision).split(decimalSeparator);
+            if (decimalSeparator !== '.') {
+              // Replace custom decimalSeparator with '.' for parseFloat function
+              parts = parseFloat(formattedValue.replace(decimalSeparator, '.')).toFixed(precision);
+              // Put custom decimalSeparator back
+              parts = parts.replace('.', decimalSeparator);
+            } else {
+              parts = parseFloat(formattedValue).toFixed(precision);
+            }
+            parts = parts.split(decimalSeparator);
           } else {
             parts = formattedValue.split(decimalSeparator);
           }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -151,7 +151,15 @@ class NumberFormat extends React.Component {
         let parts;
         if (decimalPrecision !== false) {
           const precision = decimalPrecision === true ? 2 : decimalPrecision;
-          parts = parseFloat(formattedValue).toFixed(precision).split(decimalSeparator);
+          if (decimalSeparator !== '.') {
+            // Replace custom decimalSeparator with '.' for parseFloat function
+            parts = parseFloat(formattedValue.replace(decimalSeparator, '.')).toFixed(precision)
+            // Put custom decimalSeparator back
+            parts = parts.replace('.', decimalSeparator);
+          } else {
+            parts = parseFloat(formattedValue).toFixed(precision)
+          }
+          parts = parts.split(decimalSeparator);
         } else {
           parts = formattedValue.split(decimalSeparator);
         }

--- a/test/input_test.js
+++ b/test/input_test.js
@@ -91,6 +91,17 @@ describe('NumberFormat as input', () => {
     input.simulate('change', getCustomEvent("2456981'89"));
     expect(wrapper.state().value).toEqual("$2 456 981'89");
 
+    wrapper.setProps({thousandSeparator: ",", decimalSeparator: "."});
+    input.simulate('change', getCustomEvent("2456981.89"));
+    expect(wrapper.state().value).toEqual("$2,456,981.89");
+  });
+
+  it('should support decimal precision with custom decimal separator', () => {
+    const wrapper = shallow(<NumberFormat thousandSeparator={"."} decimalSeparator={","} decimalPrecision={2} />);
+    const input = wrapper.find('input');
+
+    input.simulate('change', getCustomEvent("2456981,89");
+    expect(wrapper.state().value).toEqual("2.456.981,89");
   });
 
   it('should have proper intermediate formatting', () => {


### PR DESCRIPTION
This PR fixes [issue #37](https://github.com/s-yadav/react-number-format/issues/37)