### PR TITLE
Migrate deprecated PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   "peerDependencies": {
     "react": "^0.14 || ^15.0.0-rc || ^15.0.0",
     "react-dom": "^0.14 || ^15.0.0-rc || ^15.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -1,5 +1,6 @@
 //const React = require('react');
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");


### PR DESCRIPTION
This add the `prop-types` package and migrates the import from React to the prop-types package.