### PR TITLE
update input on mask/format change

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -48,6 +48,14 @@ class NumberFormat extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if ((prevProps.mask !== this.props.mask) || (prevProps.format !== this.props.format)) {
+      this.setState({
+        value: this.formatInput(this.props.value).formattedValue
+      });
+    }
+  }
+
   getSeparators() {
     let {thousandSeparator, decimalSeparator} = this.props;
     if (thousandSeparator === true) {

--- a/test/input_test.js
+++ b/test/input_test.js
@@ -236,6 +236,21 @@ describe('NumberFormat as input', () => {
 
   });
 
+  it('should update input value when format is updated', () => {
+    const wrapper = mount(<NumberFormat value="4111111111111111" format="################" />);
+    const input = wrapper.find('input');
+    expect(input.get(0).value).toEqual("4111111111111111");
+    wrapper.setProps({format: '#### #### #### ####'})
+    expect(input.get(0).value).toEqual("4111 1111 1111 1111");
+  });
+
+  it('should update input value when mask is updated', () => {
+    const wrapper = mount(<NumberFormat value="411111111111111" format="#### #### #### ####" mask="_" />);
+    const input = wrapper.find('input');
+    expect(input.get(0).value).toEqual("4111 1111 1111 111_");
+    wrapper.setProps({mask: '*'})
+    expect(input.get(0).value).toEqual("4111 1111 1111 111*");
+  });
 });
 
 /*** format_number input as text ****/


### PR DESCRIPTION
Input values are not updated when a mask/format is changed without the value being different. This change will force the input value to change when the mask or format is changed. `componentDidUpdate` is used instead of `componentWillReceiveProps` because many of the instance methods on the React component use `this.props.mask`/`this.props.format` which, at the time, are not the updated mask/format.

Awesome job on this component though, massive time saver!