### PR TITLE
fix: re-render on (e.g. prefix prop) update

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -41,11 +41,9 @@ class NumberFormat extends React.Component {
   }
 
   componentWillReceiveProps(newProps) {
-    if(newProps.value !== this.props.value) {
-      this.setState({
-        value : this.formatInput(newProps.value).formattedValue
-      });
-    }
+    this.setState({
+      value : this.formatInput(newProps.value).formattedValue
+    });
   }
 
   getSeparators() {


### PR DESCRIPTION
When prefix (or any another prop) is changing react-number-format must rerender itself.

Also, you can Look for `PureComponent` or `shouldComponentUpdate` for better render optimization technics.