### PR TITLE
Fix race conditions by setting cursor position synchronously

### DIFF
--- a/lib/number_format.js
+++ b/lib/number_format.js
@@ -284,18 +284,28 @@ var NumberFormat = function (_React$Component) {
 
       var cursorPos = el.selectionStart;
 
+      cursorPos = this.getCursorPosition(inputValue, formattedValue, cursorPos);
+
+      el.value = formattedValue;
+      this.setCaretPosition(el, cursorPos);
+
+      /*
+        setting caret position within timeout of 0ms is required for mobile chrome,
+        otherwise browser resets the caret position after we set it
+        We are also setting it without timeout so that in normal browser we don't see the flickering
+       */
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+      this.timeout = setTimeout(function () {
+        _this2.timeout = null;
+        if (el.value === formattedValue) {
+          _this2.setCaretPosition(el, cursorPos);
+        }
+      }, 0);
+
       //change the state
       this.setState({ value: formattedValue }, function () {
-        cursorPos = _this2.getCursorPosition(inputValue, formattedValue, cursorPos);
-        /*
-          setting caret position within timeout of 0ms is required for mobile chrome,
-          otherwise browser resets the caret position after we set it
-          We are also setting it without timeout so that in normal browser we don't see the flickering
-         */
-        _this2.setCaretPosition(el, cursorPos);
-        setTimeout(function () {
-          return _this2.setCaretPosition(el, cursorPos);
-        }, 0);
         if (callback) callback(e, value);
       });
 

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -231,17 +231,29 @@ class NumberFormat extends React.Component {
     const inputValue = el.value;
     const {formattedValue,value} = this.formatInput(inputValue);
     let cursorPos = el.selectionStart;
+    
+    cursorPos = this.getCursorPosition(inputValue, formattedValue, cursorPos );    
+    
+    el.value = formattedValue;
+    this.setCaretPosition(el, cursorPos);
+
+    /*
+      setting caret position within timeout of 0ms is required for mobile chrome,
+      otherwise browser resets the caret position after we set it
+      We are also setting it without timeout so that in normal browser we don't see the flickering
+     */
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+    this.timeout = setTimeout(() => {
+      this.timeout = null;
+      if (el.value === formattedValue) {
+        this.setCaretPosition(el, cursorPos);
+      }
+    }, 0);
 
     //change the state
     this.setState({value : formattedValue},()=>{
-      cursorPos = this.getCursorPosition(inputValue, formattedValue, cursorPos );
-      /*
-        setting caret position within timeout of 0ms is required for mobile chrome,
-        otherwise browser resets the caret position after we set it
-        We are also setting it without timeout so that in normal browser we don't see the flickering
-       */
-      this.setCaretPosition(el, cursorPos);
-      setTimeout(() => this.setCaretPosition(el, cursorPos), 0);
       if(callback) callback(e,value);
     });
 
@@ -313,4 +325,4 @@ class NumberFormat extends React.Component {
 NumberFormat.propTypes = propTypes;
 NumberFormat.defaultProps = defaultProps;
 
-module.exports =  NumberFormat;
+module.exports = NumberFormat;


### PR DESCRIPTION
Entering text quickly with an onChange that takes a long time causes a race condition. This fixes that by moving the evaluation and setting of the cursor position from the async callback from state change to the callback of the input itself. It also adds a clearTimeout for the async movement needed for Chrome Mobile.

With a long running onChange and by typing quickly, I am consistently able to get events in this order:

1. Enter first character 
2. Get state change callback from first, call long running onChange callback
3. Enter second character
4. Enter third character
5. Get state change callback from second character, move cursor to position 2 because that's how long the value from the second event is
6. Get state change callback from third character, detect cursor at position 2 and leave it there

Here's what I'm seeing in my console when I add a log:
![screen shot 2017-05-11 at 4 38 42 pm](https://cloud.githubusercontent.com/assets/339327/25970880/52e27cc6-3668-11e7-82a6-7ab3e8c8a3ab.png)

It lists 2 twice, then skips 3 and goes to 4 because it added a comma.

Putting timeout directly on `this` instead of `this.state` is needed in this situation because it must be immediately available and because changing its value should not cause a rerender.