### PR TITLE
formatExpiryChange edge case for 00 input

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -12,6 +12,9 @@ class App extends React.Component {
   }
 
   formatExpiryChange(val) {
+    if(val && val.length > 1 && Number(val[0]) < 1 && Number(val[1]) < 1){
+      val = '01'+val.substring(2,val.length);
+    }
     if(val && Number(val[0]) > 1){
       val = '0'+val;
     }


### PR DESCRIPTION
Custom format method  : Format credit card expiry time

Added a check to set the month to 01 if 00 is input, ensuring a valid month is given. Also concatenates the rest of the input as is done in the case when the first 2 input numbers are over 12.

**Note: There still seems to be a weird bug where you can add as many 0's as you want to the input box and it does not stop at 5 chars (the 4 numbers including the '/'). Also if you have a valid date of 5 chars, then you add a 0 to the input you can add ANY other char (including non numbers) after it. It seems like this is being caused by an error thrown in the getCursorPosition specifically 'TypeError: formattedValue[j] is undefined' I can add this as a separate bug in the NumberFormat class for that method when using a format function.