### PR TITLE
Fix onFocus caret reset position bug

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -668,15 +668,20 @@ class NumberFormat extends React.Component {
   }
 
   onFocus(e: SyntheticInputEvent) {
-    const el = e.target;
-    const {selectionStart, value} = el;
+    // Workaround Chrome and Safari bug https://bugs.chromium.org/p/chromium/issues/detail?id=779328
+    // (onFocus event target selectionStart is always 0 before setTimeout)
+    e.persist()
+    setTimeout(() => {
+      const el = e.target;
+      const {selectionStart, value} = el;
 
-    const caretPostion = this.correctCaretPosition(value, selectionStart);
-    if (caretPostion !== selectionStart) {
-      this.setPatchedCaretPosition(el, caretPostion, value);
-    }
+      const caretPosition = this.correctCaretPosition(value, selectionStart);
+      if (caretPosition !== selectionStart) {
+        this.setPatchedCaretPosition(el, caretPosition, value);
+      }
 
-    this.props.onFocus(e);
+      this.props.onFocus(e);
+    })
   }
 
   render() {

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -259,10 +259,26 @@ describe('Test click / focus on input', () => {
     expect(caretPos).toEqual(13);
   })
 
-  it('should correct caret position on focus', () => {
+  it('should correct wrong caret position on focus', () => {
+    jasmine.clock().install()
     const wrapper = shallow(<NumberFormat  thousandSeparator="," prefix="Rs. " suffix=" /sq.feet" value="Rs. 12,345.50 /sq.feet"/>);
 
     simulateFocusEvent(wrapper.find('input'), 0, setSelectionRange);
-    expect(caretPos).toEqual(4);
+    jasmine.clock().tick(1)
+    expect(caretPos).toEqual(4)
+    jasmine.clock().uninstall()
+  });
+
+  it('should not reset correct caret position on focus', () => {
+    jasmine.clock().install()
+    const wrapper = shallow(<NumberFormat  thousandSeparator="," prefix="Rs. " suffix=" /sq.feet" value="Rs. 12,345.50 /sq.feet"/>);
+
+    // Note: init caretPos to `6`. Focus to `6`. In case of bug, selectionStart is `0` and the caret will move to `4`.
+    //   otherwise (correct behaviour) the value will not change, and stay `6`
+    caretPos = 6
+    simulateFocusEvent(wrapper.find('input'), 6, setSelectionRange);
+    jasmine.clock().tick(1)
+    expect(caretPos).toEqual(6)
+    jasmine.clock().uninstall()
   });
 });

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -118,7 +118,9 @@ export function simulateFocusEvent(input, selectionStart, setSelectionRange) {
 
   const currentValue = input.prop('value');
 
-  const focusEvent = getEvent({}, {
+  const focusEvent = getEvent({
+    persist: noop,
+  }, {
     value: currentValue,
     selectionStart,
     selectionEnd,


### PR DESCRIPTION
This bug appears on OSX Safari and Chrome, at least. Ref https://bugs.chromium.org/p/chromium/issues/detail?id=779328

v3 now corrects focus caret position, but relies on `event.target.selectionStart`, which is not immediatelly available due to this bug. The reported value is always `0` instead of mouse position. 

This PR offers a workaround to avoid caret position reset, until browser vendors push a fix,  and is based on `v3` branch:

- Add a test to fail on this bug
- Wrap `onFocus` event handler in a `setTimetout(0)`
- Fix other on focus test to work with async behaviour

Other fix: 
- Small naming typo fix (`caretPosition`)
