### PR TITLE
Fix an issue with accessing blur event's properties

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -645,6 +645,8 @@ class NumberFormat extends React.Component {
 
       //change the state
       if (formattedValue !== lastValue) {
+        // the event needs to be persisted because its properties can be accessed in an asynchronous way
+        e.persist();
         this.setState({value : formattedValue, numAsString}, () => {
           props.onValueChange(valueObj);
           onBlur(e);

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -135,7 +135,9 @@ export function simulateFocusEvent(input, selectionStart, setSelectionRange) {
 export function simulateBlurEvent(input) {
   const currentValue = input.prop('value');
 
-  const blurEvent = getEvent({}, {
+  const blurEvent = getEvent({
+    persist: noop
+  }, {
     value: currentValue,
   });
 


### PR DESCRIPTION
When formatted value doesn't equal to the last one, `onBlur` callback is invoked in an asynchronous way. In this case according to [documentation](https://reactjs.org/docs/events.html#event-pooling) the event needs to be persisted to allow references to the event to be retained by user code.