### PR TITLE
Fix partial deletes

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -556,18 +556,6 @@ class NumberFormat extends React.Component {
       return value;
     }
 
-    const start = caretPos;
-    const lastValueParts = splitString(lastValue, caretPos);
-    const newValueParts = splitString(value, caretPos);
-    const deletedIndex = lastValueParts[1].lastIndexOf(newValueParts[1]);
-    const diff = deletedIndex !== -1 ? lastValueParts[1].substring(0, deletedIndex) : '';
-    const end = start + diff.length;
-
-    //if format got deleted reset the value to last value
-    if (this.checkIfFormatGotDeleted(start, end, lastValue)) {
-      value = lastValue;
-    }
-
     //for numbers check if beforeDecimal got deleted and there is nothing after decimal,
     //clear all numbers in such case while keeping the - sign
     if (!format) {
@@ -590,10 +578,10 @@ class NumberFormat extends React.Component {
     const {state, props} = this;
     const {isAllowed} = props;
     const lastValue = state.value || '';
-
+    
     /*Max of selectionStart and selectionEnd is taken for the patch of pixel and other mobile device caret bug*/
     const currentCaretPosition = Math.max(el.selectionStart, el.selectionEnd);
-
+    
     inputValue =  this.correctInputValue(currentCaretPosition, lastValue, inputValue);
 
     let formattedValue = this.formatInput(inputValue) || '';


### PR DESCRIPTION
I believe this component shouldn't change default behaviour dictated by html's <input> component. How it currently works: when you select all text in the component, and type a valid character, nothing happens (this is true for components that have spaces/characters as separators), or if you select part of the input, that contained separator, and press delete - nothing happens. It should always work the same way an input does - you press delete - part of the text selected is deleted, you select and type - text is overwritten.

This fixes: #121 