### PR TITLE
allowing a ref to input element when displayType=input

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ import * as NumberFormat from 'react-number-format';
 | onValueChange | (values) => {} | none | onValueChange handler accepts [values object](#values-object) |
 | isAllowed | ([values](#values-object)) => true or false | none | A checker function to check if input value is valid or not |
 | renderText | (formattedValue) => React Element | null | A renderText method useful if you want to render formattedValue in different element other than span. |
+| inputRef | (el) => {this.inputElement = el} | null | Allows direct access to the input element when displayType=input. |
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**
 

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -45,7 +45,8 @@ const propTypes = {
   onBlur: PropTypes.func,
   type: PropTypes.oneOf(['text', 'tel']),
   isAllowed: PropTypes.func,
-  renderText: PropTypes.func
+  renderText: PropTypes.func,
+  inputRef: PropTypes.func,
 };
 
 const defaultProps = {
@@ -63,7 +64,8 @@ const defaultProps = {
   onMouseUp: noop,
   onFocus: noop,
   onBlur: noop,
-  isAllowed: returnTrue
+  isAllowed: returnTrue,
+  inputRef: null,
 };
 
 class NumberFormat extends React.Component {
@@ -749,7 +751,7 @@ class NumberFormat extends React.Component {
   }
 
   render() {
-    const {type, displayType, customInput, renderText} = this.props;
+    const {type, displayType, customInput, renderText, inputRef} = this.props;
     const {value} = this.state;
 
     const otherProps = omit(this.props, propTypes);
@@ -773,6 +775,7 @@ class NumberFormat extends React.Component {
       return (
         <CustomInput
           {...inputProps}
+          ref={inputRef}
         />
       )
     }
@@ -780,6 +783,7 @@ class NumberFormat extends React.Component {
     return (
       <input
         {...inputProps}
+        ref={inputRef}
       />
     )
   }


### PR DESCRIPTION
I had an issue similar to #125 in a situation where I needed to implement a setfocus() call on the input element. 

So I've implemented the inputRef like TextField Component, allowing, for instance:

`<NumberFormat inputRef={(el) => {this.inputElement = el}} thousandSeparator={true} decimalScale={3} fixedDecimalScale={true} prefix="$" />`

Hope it helps. Cheers.