### PR TITLE
Allow password type

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -43,7 +43,7 @@ const propTypes = {
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  type: PropTypes.oneOf(['text', 'tel']),
+  type: PropTypes.oneOf(['text', 'tel', 'password']),
   isAllowed: PropTypes.func,
   renderText: PropTypes.func,
   getInputRef: PropTypes.func


### PR DESCRIPTION
Beside the prop type error message, I haven't noticed any issue with password type.
Possible use cases: cvc input.