### PR TITLE
Handle Null Case

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -447,8 +447,8 @@ class NumberFormat extends React.Component {
     const {format, decimalScale, fixedDecimalScale} = this.props;
     let {value, isNumericString} = this.props;
 
-    // if value is not defined return empty string
-    if (value === undefined) return '';
+    // if value is not defined or null return empty string
+    if (value === undefined || value === null) return '';
 
     if (typeof value === 'number') {
       value = value.toString();


### PR DESCRIPTION
We had issues when we upgraded to `3.1.3` with the library handling `null` as a value prop. 

Should be treated the same as undefined?