### PR TITLE
Insert value if entire range is selected

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -547,8 +547,7 @@ class NumberFormat extends React.Component {
     const diff = deletedIndex !== -1 ? lastValueParts[1].substring(0, deletedIndex) : '';
     const end = start + diff.length;
 
-    const isDeleteAll = lastValueParts[1].length === deletedIndex;
-
+    const isDeleteAll = newValueParts[1] === '';
     //if format got deleted reset the value to last value
     if (!isDeleteAll && this.checkIfFormatGotDeleted(start, end, lastValue)) {
       value = lastValue;

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -547,8 +547,10 @@ class NumberFormat extends React.Component {
     const diff = deletedIndex !== -1 ? lastValueParts[1].substring(0, deletedIndex) : '';
     const end = start + diff.length;
 
+    const isDeleteAll = lastValueParts[1].length === deletedIndex;
+
     //if format got deleted reset the value to last value
-    if (this.checkIfFormatGotDeleted(start, end, lastValue)) {
+    if (!isDeleteAll && this.checkIfFormatGotDeleted(start, end, lastValue)) {
       value = lastValue;
     }
 

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -278,7 +278,14 @@ describe('Test NumberFormat as input with numeric format options', () => {
     const wrapper = shallow(<NumberFormat prefix="$" decimalScale={3} value="$1.000" fixedDecimalScale={true}/>);
     simulateKeyInput(wrapper.find('input'), 'Backspace', 2);
     expect(wrapper.state().value).toEqual('')
-  })
+  });
+
+  it('should allow replace all numbers with input number when decimalScale and fixedDecimalScale is defined', () => {
+    const value = '$1.000';
+    const wrapper = shallow(<NumberFormat prefix="$" decimalScale={3} value={value} fixedDecimalScale={true}/>);
+    simulateKeyInput(wrapper.find('input'), '9', 0, value.length);
+    expect(wrapper.state().value).toEqual('$9.000')
+  });
 
   it('should not allow to remove decimalSeparator if decimalScale and fixedDecimalScale is defined', () => {
     const wrapper = shallow(<NumberFormat prefix="$" thousandSeparator={true} decimalScale={3} fixedDecimalScale={true} value="$1,234.000"/>);


### PR DESCRIPTION
When fixedDecimalScale is set to true and there is a value in the component, I am unable to overwrite the component's value entirely.

For example:
Initial component value: 4.50
Highlight/select the entire number
Type in a new number: 7

Result: Number does not change
Expected: 7.00

The description is taken from https://github.com/s-yadav/react-number-format/issues/142.
It also fixes https://github.com/s-yadav/react-number-format/issues/134.