### PR TITLE
Infinite update loop + call onValueChanged when '-' removed fix 

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -695,7 +695,7 @@ class NumberFormat extends React.Component {
     const {key} = e;
     const {selectionStart, selectionEnd, value = ''} = el;
     let expectedCaretPosition;
-    const {decimalScale, fixedDecimalScale, prefix, suffix, format, onKeyDown} = this.props;
+    const {decimalScale, fixedDecimalScale, prefix, suffix, format, onKeyDown, onValueChange} = this.props;
     const ignoreDecimalSeparator = decimalScale !== undefined && fixedDecimalScale;
     const numRegex = this.getNumberRegex(false, ignoreDecimalSeparator);
     const negativeRegex = new RegExp('-');
@@ -739,8 +739,16 @@ class NumberFormat extends React.Component {
       if (selectionStart <= leftBound + 1 && value[0] === '-' && typeof format === 'undefined') {
         const newValue = value.substring(1);
         const numAsString = this.removeFormatting(newValue);
+        const floatValue = parseFloat(numAsString);
+
+        const valueObj = {
+          newValue,
+          value: numAsString,
+          floatValue: isNaN(floatValue) ? undefined : floatValue
+        };
         this.setState({value: newValue, numAsString}, () => {
           this.setPatchedCaretPosition(el, newCaretPosition, newValue);
+          onValueChange(valueObj, e);
         });
       } else if (!negativeRegex.test(value[expectedCaretPosition])) {
         while (!numRegex.test(value[newCaretPosition - 1]) && newCaretPosition > leftBound){ newCaretPosition--; }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -144,8 +144,6 @@ class NumberFormat extends React.Component {
     }
   }
 
-  
-
   /** Misc methods **/
   getFloatString(num: string = '') {
     const {decimalScale} = this.props;

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -131,7 +131,11 @@ class NumberFormat extends React.Component {
       const formattedValue = props.value === undefined ? lastValueWithNewFormat : this.formatValueProp();
       const numAsString = this.removeFormatting(formattedValue);
 
-      if (parseFloat(numAsString) !== parseFloat(lastNumStr) || lastValueWithNewFormat !== stateValue) {
+      const numAsStringFloat = parseFloat(numAsString);
+      const lastNumStrFloat = parseFloat(lastNumStr);
+
+      if ((!isNaN(numAsStringFloat) || !isNaN(lastNumStrFloat)) &&
+      	(parseFloat(numAsString) !== parseFloat(lastNumStr) || lastValueWithNewFormat !== stateValue)) {
         this.setState({
           value : formattedValue,
           numAsString,
@@ -139,6 +143,8 @@ class NumberFormat extends React.Component {
       }
     }
   }
+
+  
 
   /** Misc methods **/
   getFloatString(num: string = '') {


### PR DESCRIPTION
This pull request addresses the following issues:

- When doing parseFloat(numAsString) and parseFloat(lastNumStr) on empty strings, it will return NaN. NaN !== NaN is true, so setState gets called continuously when you first click on an input. This causes and infinite loop and crashes the React App.

- onValueChange does not get called when removing a '-' sign using backspace. This prevents the parent component from updating it's state to use the new value. If the number-format component value prop is tied to this state it will block the '-' sign from being removed.

All tests are passing for this PR, but I would recommend writing tests for these cases.

My components look like this, using Material UI:

```
<TextField
  label="Total"
  value={valueFromRedux}
  onChange={values => {
    reduxSetterAction(values.value);
  }}
  InputProps={{
    inputComponent: NumberFormatCustom
  }}
/>
</div>

```
And NumberFormatCustom is:

```
<NumberFormat
  {...other}
  ref={inputRef}
  onValueChange={onChange}
  isAllowed={values => { return values.value.length <= 15;}}
  thousandSeparator
  decimalScale="2"
  fixedDecimalScale
  isNumericString
  allowNegative
  prefix="$"
/>
```
