### PR TITLE
Fix #181 - Move Babel transforms to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-react-transform": "^2.0.2",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.7.2",
@@ -78,6 +75,9 @@
     "react-dom": "^0.14 || ^15.0.0-rc || ^15.0.0 || ^16.0.0-rc || ^16.0.0"
   },
   "dependencies": {
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.6.0"
   }


### PR DESCRIPTION
This change fixes issue #181 by moving the Babel transforms to the `dependencies`, where they will be available to .babelrc when compiling surrounding projects in non-development environments.