### PR TITLE
Fix input of negative number in case of isNumericString & decimalScale

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -60,7 +60,7 @@ export function limitToScale(numStr: string, scale: number, fixedDecimalScale: b
  */
 export function roundToPrecision(numStr: string, scale: number, fixedDecimalScale: boolean) {
   //if number is empty don't do anything return empty string
-  if (numStr === '') return '';
+  if (['', '-'].includes(numStr)) return numStr;
 
   const shoudHaveDecimalSeparator = numStr.indexOf('.') !== -1 && scale;
   const {beforeDecimal, afterDecimal, hasNagation} = splitDecimal(numStr);

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -467,4 +467,28 @@ describe('Test NumberFormat as input with numeric format options', () => {
     expect(wrapper.state().value).toEqual('1');
   });
 
+  it(`should not add 0 after minus immediately after minus is entered in case isNumericString and
+    decimalScale props are passed`, () => {
+    class IssueExample extends React.Component {
+      constructor() {
+        super();
+        this.state = {
+          value: ''
+        };
+      }
+      render() {
+        return (
+          <NumberFormat
+            value={this.state.value}
+            isNumericString
+            onValueChange={({value}) => this.setState({value})}
+            decimalScale={2}
+          />
+        )
+      }
+    }
+    const wrapper = mount(<IssueExample/> );
+    simulateKeyInput(wrapper.find('input'), '-');
+    expect(wrapper.find('input').instance().value).toEqual('-');
+  });
 });


### PR DESCRIPTION
I used a component similar to the following:
```
<NumberFormat
  value={this.state.value}
  isNumericString
  onValueChange={({value}) => this.setState({value})}
  decimalScale={2}
/>
```
And the combination of isNumericString and decimalScale props caused bug with entering negative number. When I entered minus sign, input immediately showed "-0" and this zero could not be removed using backspace.