### PR TITLE
Typescript: Allow using native Input props

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -21,7 +21,7 @@ declare module "react-number-format" {
   }
 
   export interface NumberFormatProps
-    extends React.HTMLAttributes<HTMLInputElement> {
+    extends React.InputHTMLAttributes<HTMLInputElement> {
     thousandSeparator?: boolean | string;
     decimalSeparator?: boolean | string;
     decimalScale?: number;

--- a/typings/number_format.spec.tsx
+++ b/typings/number_format.spec.tsx
@@ -3,3 +3,4 @@ import { default as NumberFormat } from "react-number-format";
 
 <NumberFormat value="" />;
 <NumberFormat type="tel" />;
+<NumberFormat type="tel" readOnly={false} />;


### PR DESCRIPTION
Hey @s-yadav, thanks for adding types to this library. 

There is a problem when using default input props like `readOnly` or `autoFocus` because the type is extending `HTMLAttributes` and not `InputHTMLAttributes`.

I have added a small test case too, don't know if I should expand it.