### PR TITLE
Fix IE 11 issue

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -815,7 +815,8 @@ class NumberFormat extends React.Component {
 
     const otherProps = omit(this.props, propTypes);
 
-    const inputProps = Object.assign({}, otherProps, {
+    const inputProps = {
+      ...otherProps,
       type,
       value,
       onChange: this.onChange,
@@ -823,7 +824,7 @@ class NumberFormat extends React.Component {
       onMouseUp: this.onMouseUp,
       onFocus: this.onFocus,
       onBlur: this.onBlur
-    })
+    }
 
     if( displayType === 'text'){
       return renderText ? (renderText(value) || null) : <span {...otherProps} ref={getInputRef}>{value}</span>;


### PR DESCRIPTION
Object.assign isn't transformed when published on NPM. It's doesn't work with IE 11 nor with Chrome 41, the engine used by the Google crawler.