### PR TITLE
Allow removal of format if user has a selection

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -628,8 +628,9 @@ class NumberFormat extends React.Component {
       return value;
     }
 
-    //if format got deleted reset the value to last value
-    if (this.checkIfFormatGotDeleted(start, end, lastValue)) {
+    //if format got deleted reset the value to last value, unless the user has
+    //a selection spanning multiple characters
+    if (this.checkIfFormatGotDeleted(start, end, lastValue) && start === end) {
       value = lastValue;
     }
 


### PR DESCRIPTION
If a user selects multiple characters which spans a prefix and then attempts to delete or change their selection, the input reverts to previous value.

https://codepen.io/s-yadav/pen/bpKNMa

## Deleting
Steps to reproduce:
1. Move to "Prefix and thousand separator : Format currency in input" input
2. Using mouse; select '$1'
3. Hit delete/backspace

Expected:
Input updates to '$23,967'

Actual:
Input reverts to '$123,967'

## Editing

Steps to reproduce:
1. Move to "Prefix and thousand separator : Format currency in input" input
2. Using mouse; select '$1'
3. Hit '2'

Expected:
Input updates to '$223,967'

Actual:
Input reverts to '$123,967'