### PR TITLE
Added a disabled prop to the input props to allow <input> to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ In typescript you also have to enable `"esModuleInterop": true` in your tsconfig
 | onValueChange | (values) => {} | none | onValueChange handler accepts [values object](#values-object) |
 | isAllowed | ([values](#values-object)) => true or false | none | A checker function to check if input value is valid or not |
 | renderText | (formattedValue) => React Element | null | A renderText method useful if you want to render formattedValue in different element other than span. |
+| disabled | boolean | false | If true it will disable the input field and not include the input value when the form is submitted |
 | getInputRef | (elm) => void | null | Method to get reference of input or span based on displayType prop. See [Getting reference](#getting-reference)
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -72,6 +72,19 @@ class App extends React.Component {
 
         <div className="example">
           <h3>
+            Disabled input field
+          </h3>
+          <NumberFormat
+            prefix="$"
+            thousandSeparator={true}
+            decimalScale={3}
+            fixedDecimalScale={true}
+            disabled
+            />
+        </div>
+
+        <div className="example">
+          <h3>
             Decimal scale : Format currency in input with decimal scale
           </h3>
           <NumberFormat thousandSeparator={true} decimalScale={3} fixedDecimalScale={true} prefix="$" />

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -55,6 +55,7 @@ const propTypes = {
   onBlur: PropTypes.func,
   type: PropTypes.oneOf(['text', 'tel', 'password']),
   isAllowed: PropTypes.func,
+  disabled: PropTypes.bool,
   renderText: PropTypes.func,
   getInputRef: PropTypes.func
 };
@@ -69,6 +70,7 @@ const defaultProps = {
   allowNegative: true,
   allowEmptyFormatting: false,
   isNumericString: false,
+  disabled: false,
   type: 'text',
   onValueChange: noop,
   onChange: noop,
@@ -870,7 +872,7 @@ class NumberFormat extends React.Component {
   }
 
   render() {
-    const {type, displayType, customInput, renderText, getInputRef} = this.props;
+    const {type, displayType, customInput, renderText, getInputRef, disabled} = this.props;
     const {value} = this.state;
 
     const otherProps = omit(this.props, propTypes);
@@ -878,6 +880,7 @@ class NumberFormat extends React.Component {
     const inputProps = Object.assign({}, otherProps, {
       type,
       value,
+      disabled,
       onChange: this.onChange,
       onKeyDown: this.onKeyDown,
       onMouseUp: this.onMouseUp,


### PR DESCRIPTION
NumberFormat component does not currently allow for the <input> element to be disabled. This PR contains an additional 'disabled' prop that disables the input field.