### PR TITLE
Add a boolean prop to allow leading zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ In typescript you also have to enable `"esModuleInterop": true` in your tsconfig
 | fixedDecimalScale | boolean| false| If true it add 0s to match given decimalScale|
 | allowNegative      | boolean     |   true | allow negative numbers (Only when format option is not provided) |
 | allowEmptyFormatting | boolean | true | Apply formatting to empty inputs |
+| allowLeadingZeros | boolean | false | Allow leading zeros at beginning of number |
 | prefix      | String (ex : $)     |   none | Add a prefix before the number |
 | suffix | String (ex : /-)      |    none | Add a suffix after the number |
 | value | Number or String | null | Value to the number format. It can be a float number, or formatted string. If value is string representation of number (unformatted), isNumericString props should be passed as true. |

--- a/lib/number_format.js
+++ b/lib/number_format.js
@@ -51,6 +51,7 @@ var propTypes = {
   customInput: _propTypes.default.func,
   allowNegative: _propTypes.default.bool,
   allowEmptyFormatting: _propTypes.default.bool,
+  allowLeadingZeros: _propTypes.default.bool,
   onValueChange: _propTypes.default.func,
   onKeyDown: _propTypes.default.func,
   onMouseUp: _propTypes.default.func,
@@ -71,6 +72,7 @@ var defaultProps = {
   suffix: '',
   allowNegative: true,
   allowEmptyFormatting: false,
+  allowLeadingZeros: false,
   isNumericString: false,
   type: 'text',
   onValueChange: _utils.noop,
@@ -790,13 +792,14 @@ function (_React$Component) {
       var props = this.props,
           state = this.state;
       var format = props.format,
-          onBlur = props.onBlur;
+          onBlur = props.onBlur,
+          allowLeadingZeros = props.allowLeadingZeros;
       var numAsString = state.numAsString;
       var lastValue = state.value;
       this.focusedElm = null;
 
       if (!format) {
-        numAsString = (0, _utils.fixLeadingZero)(numAsString);
+        numAsString = allowLeadingZeros ? numAsString : (0, _utils.fixLeadingZero)(numAsString);
         var formattedValue = this.formatNumString(numAsString); //change the state
 
         if (formattedValue !== lastValue) {

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -47,6 +47,7 @@ const propTypes = {
   customInput: PropTypes.func,
   allowNegative: PropTypes.bool,
   allowEmptyFormatting: PropTypes.bool,
+  allowLeadingZeros: PropTypes.bool,
   onValueChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onMouseUp: PropTypes.func,
@@ -68,6 +69,7 @@ const defaultProps = {
   suffix: '',
   allowNegative: true,
   allowEmptyFormatting: false,
+  allowLeadingZeros: false,
   isNumericString: false,
   type: 'text',
   onValueChange: noop,
@@ -728,14 +730,14 @@ class NumberFormat extends React.Component {
 
   onBlur(e: SyntheticInputEvent) {
     const {props, state} = this;
-    const {format, onBlur} = props;
+    const {format, onBlur, allowLeadingZeros} = props;
     let {numAsString} = state;
     const lastValue = state.value;
 
     this.focusedElm = null;
 
     if (!format) {
-      numAsString = fixLeadingZero(numAsString);
+      numAsString = allowLeadingZeros ? numAsString : fixLeadingZero(numAsString);
       const formattedValue = this.formatNumString(numAsString);
 
       //change the state

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -365,7 +365,7 @@ describe('Test NumberFormat as input with numeric format options', () => {
     expect(wrapper.state().value).toEqual('$20,000.25');
   });
 
-  it('should remove leading 0s while user go out of focus', () => {
+  it('should remove leading 0s while user go out of focus and allowLeadingZeros is false', () => {
     const wrapper = shallow(<NumberFormat value={23456.78} thousandSeparator={','} decimalSeparator={'.'} prefix={'$'}/> );
 
     simulateKeyInput(wrapper.find('input'), '0', 1);
@@ -379,6 +379,22 @@ describe('Test NumberFormat as input with numeric format options', () => {
     simulateKeyInput(wrapper.find('input'), 'Backspace', 2);
     simulateBlurEvent(wrapper.find('input'));
     expect(wrapper.state().value).toEqual('$0.25');
+  });
+
+  it('should not remove leading 0s while user go out of focus and allowLeadingZeros is true', () => {
+    const wrapper = shallow(<NumberFormat value={23456.78} thousandSeparator={','} decimalSeparator={'.'} prefix={'$'} allowLeadingZeros={true}/> );
+
+    simulateKeyInput(wrapper.find('input'), '0', 1);
+    simulateBlurEvent(wrapper.find('input'));
+
+    expect(wrapper.state().value).toEqual('$023,456.78');
+
+    wrapper.setProps({value: 10000.25});
+    wrapper.update();
+
+    simulateKeyInput(wrapper.find('input'), 'Backspace', 2);
+    simulateBlurEvent(wrapper.find('input'));
+    expect(wrapper.state().value).toEqual('$0,000.25');
   });
 
   it('should add 0 before decimal if user is in focus', () => {


### PR DESCRIPTION
Hi,

this is a small proposition for a prop to disable the removal of leading zeros on `onBlur` method.

This is because of a special case where I want the user to be able to enter a number with leading zeros that will become the suffix of another number, hence the auto removal of leading zeros breaks the behaviour.

Don't hesitate if you have any question !

Thanks