### PR TITLE
formatAsANumber ignores decimalSeparator property

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -458,7 +458,7 @@ class NumberFormat extends React.Component {
     const {decimalScale, fixedDecimalScale, prefix, suffix, allowNegative, thousandsGroupStyle} = this.props;
     const {thousandSeparator, decimalSeparator} = this.getSeparators();
 
-    const hasDecimalSeparator = numStr.indexOf('.') !== -1 || (decimalScale && fixedDecimalScale);
+    const hasDecimalSeparator = numStr.indexOf(decimalSeparator) !== -1 || (decimalScale && fixedDecimalScale);
     let {beforeDecimal, afterDecimal, addNegation} = splitDecimal(numStr, allowNegative); // eslint-disable-line prefer-const
 
     //apply decimal precision if its defined


### PR DESCRIPTION
It always tries to find dot.
I haven't tested this solution. It is based on static code analysis exclusively 