### PR TITLE
Add module field to package.json for module bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "React component to format number in an input or as a text.",
   "version": "4.0.8",
   "main": "lib/number_format.js",
+  "module": "dist/react-number-format.es.js",
   "author": "Sudhanshu Yadav",
   "license": "MIT",
   "types": "typings/number_format.d.ts",


### PR DESCRIPTION
Hi,

You were building an esm module without specifying it in the package.json for module bundler (like Webpack). I added the required field and now apps that support it will point to the .es file instead of the umd.