### PR TITLE
Adds getInputRef to the CustomInput

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -893,6 +893,7 @@ class NumberFormat extends React.Component {
       return (
         <CustomInput
           {...inputProps}
+          ref = {getInputRef}
         />
       )
     }


### PR DESCRIPTION
We are using material ui text inputs and need the ability to programmatically trigger focus on the custom input. This adds this capability and I wasn't sure if there was a reason this wasn't propagated to custom inputs. I also wasn't sure what is easiest for you associated to the library. I didn't submit this pull request with the built resources but if you would like that let me know and I will compile it and commit that. Thanks for the number format library!