### PR TITLE
Add allowLeadingZeros property.  Bypass applying thousandSeparator when left side of decimal is zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ In typescript you also have to enable `"esModuleInterop": true` in your tsconfig
 | fixedDecimalScale | boolean| false| If true it add 0s to match given decimalScale|
 | allowNegative      | boolean     |   true | allow negative numbers (Only when format option is not provided) |
 | allowEmptyFormatting | boolean | true | Apply formatting to empty inputs |
+| allowLeadingZeros | boolean | false | Allow leading zeros at beginning of number |
 | prefix      | String (ex : $)     |   none | Add a prefix before the number |
 | suffix | String (ex : /-)      |    none | Add a suffix after the number |
 | value | Number or String | null | Value to the number format. It can be a float number, or formatted string. If value is string representation of number (unformatted), isNumericString props should be passed as true. |

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -50,6 +50,13 @@ class App extends React.Component {
 
         <div className="example">
           <h3>
+            Allow Leading Zeros: Will retain leading zeros onBlur
+          </h3>
+          <NumberFormat allowLeadingZeros={true}/>
+        </div>
+
+        <div className="example">
+          <h3>
             Indian (lakh) style number grouping
           </h3>
           <NumberFormat
@@ -83,14 +90,14 @@ class App extends React.Component {
             Custom thousand separator : Format currency in input
           </h3>
           <div>
-            ThousandSeperator: '.', decimalSeparator=','
+            ThousandSeparator: '.', decimalSeparator=','
           </div>
           <div>
             <NumberFormat thousandSeparator="." decimalSeparator="," prefix="$" />
           </div>
           <br/>
           <div>
-            ThousandSeperator: ' ', decimalSeparator='.'
+            ThousandSeparator: ' ', decimalSeparator='.'
           </div>
           <div>
             <NumberFormat thousandSeparator=" " decimalSeparator="." prefix="$" />
@@ -102,14 +109,14 @@ class App extends React.Component {
             Custom thousand separator with decimal precision
           </h3>
           <div>
-            ThousandSeperator: ',', decimalSeparator='.', decimalScale:2
+            ThousandSeparator: ',', decimalSeparator='.', decimalScale:2
           </div>
           <div>
             <NumberFormat thousandSeparator=","  decimalSeparator="." decimalScale={2} />
           </div>
           <br/>
           <div>
-            ThousandSeperator: '.', decimalSeparator=',', decimalScale:2
+            ThousandSeparator: '.', decimalSeparator=',', decimalScale:2
           </div>
           <div>
             <NumberFormat thousandSeparator="."  decimalSeparator=","  decimalScale={2} />

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -47,6 +47,7 @@ const propTypes = {
   customInput: PropTypes.elementType,
   allowNegative: PropTypes.bool,
   allowEmptyFormatting: PropTypes.bool,
+  allowLeadingZeros: PropTypes.bool,
   onValueChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onMouseUp: PropTypes.func,
@@ -68,6 +69,7 @@ const defaultProps = {
   suffix: '',
   allowNegative: true,
   allowEmptyFormatting: false,
+  allowLeadingZeros: false,
   isNumericString: false,
   type: 'text',
   onValueChange: noop,
@@ -455,7 +457,7 @@ class NumberFormat extends React.Component {
    * @return {string} formatted Value
    */
   formatAsNumber(numStr: string) {
-    const {decimalScale, fixedDecimalScale, prefix, suffix, allowNegative, thousandsGroupStyle} = this.props;
+    const {decimalScale, fixedDecimalScale, prefix, suffix, allowNegative, thousandsGroupStyle, value} = this.props;
     const {thousandSeparator, decimalSeparator} = this.getSeparators();
 
     const hasDecimalSeparator = numStr.indexOf('.') !== -1 || (decimalScale && fixedDecimalScale);
@@ -465,7 +467,9 @@ class NumberFormat extends React.Component {
     if (decimalScale !== undefined) afterDecimal = limitToScale(afterDecimal, decimalScale, fixedDecimalScale);
 
     if(thousandSeparator) {
-      beforeDecimal = applyThousandSeparator(beforeDecimal, thousandSeparator, thousandsGroupStyle);
+      const beforeDecimalNumAsString = this.removeFormatting(beforeDecimal);
+      const beforeDecimalFloatValue = parseFloat(beforeDecimalNumAsString);
+      if (beforeDecimalFloatValue !== 0) beforeDecimal = applyThousandSeparator(beforeDecimal, thousandSeparator, thousandsGroupStyle);
     }
 
     //add prefix and suffix
@@ -728,14 +732,14 @@ class NumberFormat extends React.Component {
 
   onBlur(e: SyntheticInputEvent) {
     const {props, state} = this;
-    const {format, onBlur} = props;
+    const {format, onBlur, allowLeadingZeros} = props;
     let {numAsString} = state;
     const lastValue = state.value;
 
     this.focusedElm = null;
 
     if (!format) {
-      numAsString = fixLeadingZero(numAsString);
+      numAsString = allowLeadingZeros ? numAsString : fixLeadingZero(numAsString);
       const formattedValue = this.formatNumString(numAsString);
 
       //change the state

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -457,7 +457,7 @@ class NumberFormat extends React.Component {
    * @return {string} formatted Value
    */
   formatAsNumber(numStr: string) {
-    const {decimalScale, fixedDecimalScale, prefix, suffix, allowNegative, thousandsGroupStyle, value} = this.props;
+    const {decimalScale, fixedDecimalScale, prefix, suffix, allowNegative, thousandsGroupStyle} = this.props;
     const {thousandSeparator, decimalSeparator} = this.getSeparators();
 
     const hasDecimalSeparator = numStr.indexOf('.') !== -1 || (decimalScale && fixedDecimalScale);

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -467,9 +467,7 @@ class NumberFormat extends React.Component {
     if (decimalScale !== undefined) afterDecimal = limitToScale(afterDecimal, decimalScale, fixedDecimalScale);
 
     if(thousandSeparator) {
-      const beforeDecimalNumAsString = this.removeFormatting(beforeDecimal);
-      const beforeDecimalFloatValue = parseFloat(beforeDecimalNumAsString);
-      if (beforeDecimalFloatValue !== 0) beforeDecimal = applyThousandSeparator(beforeDecimal, thousandSeparator, thousandsGroupStyle);
+      beforeDecimal = applyThousandSeparator(beforeDecimal, thousandSeparator, thousandsGroupStyle);
     }
 
     //add prefix and suffix
@@ -739,7 +737,10 @@ class NumberFormat extends React.Component {
     this.focusedElm = null;
 
     if (!format) {
-      numAsString = allowLeadingZeros ? numAsString : fixLeadingZero(numAsString);
+      if (!allowLeadingZeros) {
+        numAsString = fixLeadingZero(numAsString);
+      }
+      
       const formattedValue = this.formatNumString(numAsString);
 
       //change the state

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,8 @@ export function getThousandsGroupRegex(thousandsGroupStyle: string) {
 
 export function applyThousandSeparator(str: string, thousandSeparator: string, thousandsGroupStyle: string) {
   const thousandsGroupRegex = getThousandsGroupRegex(thousandsGroupStyle);
-  const index = str.search(/[1-9]/);
+  let index = str.search(/[1-9]/);
+  index = index === -1 ? str.length : index;
   return str.substring(0, index) + str.substring(index, str.length).replace(thousandsGroupRegex, '$1' + thousandSeparator);
 }
 

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -78,7 +78,7 @@ describe('Test NumberFormat as input with numeric format options', () => {
   });
 
 
-  it('should support custom thousand seperator', () => {
+  it('should support custom thousand separator', () => {
     const wrapper = shallow(<NumberFormat thousandSeparator={'.'} decimalSeparator={','} prefix={'$'} />);
     simulateKeyInput(wrapper.find('input'), '2456981,89', 0);
 
@@ -339,7 +339,7 @@ describe('Test NumberFormat as input with numeric format options', () => {
     expect(wrapper.state().value).toEqual('1,235');
   });
 
-  it('should allow decimal seperator and thousand separator on suffix prefix', () => {
+  it('should allow decimal separator and thousand separator on suffix prefix', () => {
     const wrapper = shallow(<NumberFormat value={1231237.56} thousandSeparator={','} decimalSeparator={'.'} prefix={'$'} suffix={' per sq. ft.'}/> );
     expect(wrapper.state().value).toEqual('$1,231,237.56 per sq. ft.');
 
@@ -359,13 +359,13 @@ describe('Test NumberFormat as input with numeric format options', () => {
 
     simulateKeyInput(wrapper.find('input'), 'Backspace', 2);
 
-    expect(wrapper.state().value).toEqual('$0,000.25');
+    expect(wrapper.state().value).toEqual('$0000.25');
 
     simulateKeyInput(wrapper.find('input'), '2', 1);
     expect(wrapper.state().value).toEqual('$20,000.25');
   });
 
-  it('should remove leading 0s while user go out of focus', () => {
+  it('should remove leading 0s while user go out of focus and allowLeadingZeros is false', () => {
     const wrapper = shallow(<NumberFormat value={23456.78} thousandSeparator={','} decimalSeparator={'.'} prefix={'$'}/> );
 
     simulateKeyInput(wrapper.find('input'), '0', 1);
@@ -379,6 +379,22 @@ describe('Test NumberFormat as input with numeric format options', () => {
     simulateKeyInput(wrapper.find('input'), 'Backspace', 2);
     simulateBlurEvent(wrapper.find('input'));
     expect(wrapper.state().value).toEqual('$0.25');
+  });
+
+  it('should not remove leading 0s while user go out of focus and allowLeadingZeros is true', () => {
+    const wrapper = shallow(<NumberFormat value={23456.78} thousandSeparator={','} decimalSeparator={'.'} prefix={'$'} allowLeadingZeros={true}/> );
+
+    simulateKeyInput(wrapper.find('input'), '0', 1);
+    simulateBlurEvent(wrapper.find('input'));
+
+    expect(wrapper.state().value).toEqual('$023,456.78');
+
+    wrapper.setProps({value: 10000.25});
+    wrapper.update();
+
+    simulateKeyInput(wrapper.find('input'), 'Backspace', 2);
+    simulateBlurEvent(wrapper.find('input'));
+    expect(wrapper.state().value).toEqual('$0000.25');
   });
 
   it('should add 0 before decimal if user is in focus', () => {


### PR DESCRIPTION
@s-yadav I reviewed the code regarding not applying the thousandSeparator when the number is zero.  It din't appear to exist so I added it for you. Thanks!