### PR TITLE
Add `allowedDecimalSeparators` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ In typescript you also have to enable `"esModuleInterop": true` in your tsconfig
 | isAllowed | ([values](#values-object)) => true or false | none | A checker function to check if input value is valid or not |
 | renderText | (formattedValue) => React Element | null | A renderText method useful if you want to render formattedValue in different element other than span. |
 | getInputRef | (elm) => void | null | Method to get reference of input, span (based on displayType prop) or the customInput's reference. See [Getting reference](#getting-reference)
+| allowedDecimalSeparators | array of char | none | Characters which when pressed result in a decimal separator. When missing, decimal separator and '.' are used |
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**
 

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -172,6 +172,10 @@ class App extends React.Component {
           <NumberFormat customInput={TextField} format="#### #### #### ####" />
         </div>
 
+        <div className="example">
+          <h3>Custom allowed decimal separators</h3>
+          <NumberFormat thousandSeparator=" "  decimalSeparator="." allowedDecimalSeparators={['.', ',']} />
+        </div>
       </div>
     )
   }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -23,6 +23,7 @@ import {
 const propTypes = {
   thousandSeparator: PropTypes.oneOfType([PropTypes.string, PropTypes.oneOf([true])]),
   decimalSeparator: PropTypes.string,
+  allowedDecimalSeparators: PropTypes.arrayOf(PropTypes.string),
   thousandsGroupStyle: PropTypes.oneOf(['thousand', 'lakh', 'wan']),
   decimalScale: PropTypes.number,
   fixedDecimalScale: PropTypes.bool,
@@ -197,15 +198,22 @@ class NumberFormat extends React.Component {
 
   getSeparators() {
     const {decimalSeparator} = this.props;
-    let {thousandSeparator} = this.props;
+    let {thousandSeparator, allowedDecimalSeparators} = this.props;
 
     if (thousandSeparator === true) {
       thousandSeparator = ','
     }
+    if (!allowedDecimalSeparators) {
+      allowedDecimalSeparators = [decimalSeparator]
+      if (decimalSeparator !== '.') {
+        allowedDecimalSeparators = allowedDecimalSeparators.concat(['.'])
+      }
+    }
 
     return {
       decimalSeparator,
-      thousandSeparator
+      thousandSeparator,
+      allowedDecimalSeparators,
     }
   }
 
@@ -603,13 +611,13 @@ class NumberFormat extends React.Component {
    **/
   correctInputValue(caretPos: number, lastValue: string, value: string) {
     const {format, allowNegative, prefix, suffix} = this.props;
-    const {decimalSeparator} = this.getSeparators();
+    const {allowedDecimalSeparators, decimalSeparator} = this.getSeparators();
     const lastNumStr = this.state.numAsString || '';
     const {selectionStart, selectionEnd} = this.selectionBeforeInput;
     const {start, end} = findChangedIndex(lastValue, value);
 
-    /** Check if only . is added in the numeric format and replace it with decimal separator */
-    if (!format && decimalSeparator !== '.' && start === end && value[selectionStart] === '.') {
+    /** Check for any allowed decimal separator is added in the numeric format and replace it with decimal separator */
+    if (!format && start === end && allowedDecimalSeparators.includes(value[selectionStart])) {
       return value.substr(0, selectionStart) + decimalSeparator + value.substr(selectionStart + 1, value.length);
     }
 

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -204,10 +204,7 @@ class NumberFormat extends React.Component {
       thousandSeparator = ','
     }
     if (!allowedDecimalSeparators) {
-      allowedDecimalSeparators = [decimalSeparator]
-      if (decimalSeparator !== '.') {
-        allowedDecimalSeparators = allowedDecimalSeparators.concat(['.'])
-      }
+      allowedDecimalSeparators = [decimalSeparator, '.']
     }
 
     return {
@@ -617,7 +614,7 @@ class NumberFormat extends React.Component {
     const {start, end} = findChangedIndex(lastValue, value);
 
     /** Check for any allowed decimal separator is added in the numeric format and replace it with decimal separator */
-    if (!format && start === end && allowedDecimalSeparators.includes(value[selectionStart])) {
+    if (!format && start === end && allowedDecimalSeparators.indexOf(value[selectionStart]) !== -1  ) {
       return value.substr(0, selectionStart) + decimalSeparator + value.substr(selectionStart + 1, value.length);
     }
 

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -104,6 +104,25 @@ describe('NumberFormat as input', () => {
   })
 
 
+  it('handles multiple different allowed decimal separators', () => {
+    const allowedDecimalSeparators = [',', '.', 'm']
+
+    const wrapper = shallow(<NumberFormat decimalSeparator={','} allowedDecimalSeparators={allowedDecimalSeparators} />);
+
+    allowedDecimalSeparators.forEach((separator) => {
+      wrapper.setProps({value: '12'});
+      simulateKeyInput(wrapper.find('input'), separator, 2);
+      expect(wrapper.state().value).toEqual('12,');
+    });
+  });
+
+  it('accepts dot as even when decimal separator is separate', () => {
+    const wrapper = shallow(<NumberFormat decimalSeparator={','} />);
+    wrapper.setProps({value: '12'});
+    simulateKeyInput(wrapper.find('input'), '.', 2);
+    expect(wrapper.state().value).toEqual('12,');
+  });
+
   it('works with custom input', () => {
     const WrapperComponent = (props) => {
       return (


### PR DESCRIPTION
When defined, this prop defines which keys to accept as decimal
separators. This is useful in cases where users might want to enter both
comma and dot as separators

Related issues: #324, #133, #223, #261