### PR TITLE
Allow null value in TypeScript typing

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -39,7 +39,7 @@ declare module "react-number-format" {
     format?: string | FormatInputValueFunction;
     removeFormatting?: (formattedValue: string) => string;
     mask?: string | string[];
-    value?: number | string;
+    value?: number | string | null;
     defaultValue?: number | string;
     isNumericString?: boolean;
     customInput?: React.ComponentType<any>;


### PR DESCRIPTION
Pretty trivial PR, but since you need to be able to set the `value` prop to `null`, seems like it should be allowed in the typings.

That said, the behavior itself did confuse me. [This line specifically](https://github.com/s-yadav/react-number-format/blob/master/src/number_format.js#L142), where you ignore the `value` prop if it is `undefined`....  I guess you are using `value={undefined}` as a signal from the consumer that they want the NumberFormat to be stateful?

Might be better to have an explicit `stateless` prop. But maybe there's just some inevitable confusion when you can use the same component in either way.

I could add a bit to the readme about passing `null` if you are trying to use the NumberFormat as a stateless component.