### PR TITLE
Add missing typescript typings

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -58,6 +58,7 @@ declare module "react-number-format" {
     isAllowed?: (values: NumberFormatValues) => boolean;
     renderText?: (formattedValue: string) => React.ReactNode;
     getInputRef?: ((el: HTMLInputElement) => void) | React.Ref<any>;
+    allowedDecimalSeparators?: Array<string>;
     [key: string]: any;
   }
 


### PR DESCRIPTION
In my previous PR (https://github.com/s-yadav/react-number-format/pull/345) I added a new prop but no new typing for it. Oops.