### PR TITLE
getInputRef should not be default noop

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -79,8 +79,7 @@ const defaultProps = {
   onMouseUp: noop,
   onFocus: noop,
   onBlur: noop,
-  isAllowed: returnTrue,
-  getInputRef: noop,
+  isAllowed: returnTrue
 };
 
 class NumberFormat extends React.Component {


### PR DESCRIPTION
If getInputRef is noop by default, a ref is given to the customInput, when used. 
Causing a ugly warning in React.