### PR TITLE
Suggest to use Yarn for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,9 @@ Feature Addition
 
 
 ### Development
-- Download the zip
-- `npm install`
+- Clone the repository or download the zip
+- `npm i -g yarn` to download Yarn
+- `yarn` to install dependencies
 - `npm start` to run example server
 - `npm run test` to test changes
 - `npm run bundle` to bundle files

--- a/README.md
+++ b/README.md
@@ -289,11 +289,11 @@ Feature Addition
 - Clone the repository or download the zip
 - `npm i -g yarn` to download Yarn
 - `yarn` to install dependencies
-- `npm start` to run example server
-- `npm run test` to test changes
-- `npm run bundle` to bundle files
+- `yarn start` to run example server
+- `yarn test` to test changes
+- `yarn bundle` to bundle files
 
 #### Testing
 Test cases are written in jasmine and run by karma
 Test file : /test/test_input.js
-To run test : `npm run test`
+To run test : `yarn test`


### PR DESCRIPTION
Because there is a `yarn.lock` and no `package-lock.json`, it's better for developers to use Yarn as a dependency management tool.

I've updated the README.

Also, I didn't know if I should change the `npm` commands too, for example
- `npm start` > `yarn start`
- `npm run bundle` > `yarn bundle`

What's your opinion on this ?