### PR TITLE
Reflect possible undefined floatValue in typings

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -13,7 +13,7 @@ declare module "react-number-format" {
   }
 
   export interface NumberFormatValues {
-    floatValue: number;
+    floatValue: number | undefined;
     formattedValue: string;
     value: string;
   }


### PR DESCRIPTION
This value can be set explicitly to `undefined`, e.g. when the user clears the field:

https://github.com/s-yadav/react-number-format/blob/b233bd68c7cd16c63287c3aa4df576c2ff80eca9/src/number_format.js#L225
