### PR TITLE
Notify value changes ASAP to prevent infinite setState loop

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -697,10 +697,9 @@ class NumberFormat extends React.Component {
 
     //update state if value is changed
     if (formattedValue !== lastValue) {
-      this.setState({value : formattedValue, numAsString}, () => {
-        onValueChange(this.getValueObject(formattedValue, numAsString));
-        onUpdate();
-      });
+      this.setState({value : formattedValue, numAsString});
+      onValueChange(this.getValueObject(formattedValue, numAsString));
+      onUpdate();
     } else {
       onUpdate();
     }
@@ -748,7 +747,7 @@ class NumberFormat extends React.Component {
       if (!allowLeadingZeros) {
         numAsString = fixLeadingZero(numAsString);
       }
-      
+
       const formattedValue = this.formatNumString(numAsString);
 
       //change the state


### PR DESCRIPTION
Patch `<NumberFormat>` to notify parent components about value changes as soon as possible, to prevent infinite `setState` loop as discovered in https://github.com/s-yadav/react-number-format/issues/277#issuecomment-509938027

That way when `<NumberFormat>` is being controlled, its parent component can learn about new value at the first time and then trigger a render with new value passed to `<NumberFormat>` prop.