### PR TITLE
fix: Clear focusTimeout timeout on unmount

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -134,10 +134,7 @@ class NumberFormat extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.focusTimeout != null) {
-      clearTimeout(this.focusTimeout);
-      this.focusTimeout = undefined;
-    }
+    clearTimeout(this.focusTimeout);
   }
 
   updateValueIfRequired(prevProps: Object) {
@@ -760,10 +757,8 @@ class NumberFormat extends React.Component {
     let {numAsString} = state;
     const lastValue = state.value;
     this.focusedElm = null;
-    if (this.focusTimeout){
-      clearTimeout(this.focusTimeout);
-      this.focusTimeout = undefined;
-    }
+
+    clearTimeout(this.focusTimeout);
 
 
     if (!format) {

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -133,6 +133,12 @@ class NumberFormat extends React.Component {
     this.updateValueIfRequired(prevProps);
   }
 
+  componentWillUnmount() {
+    if (this.focusTimeout != null) {
+      clearTimeout(this.focusTimeout);
+    }
+  }
+
   updateValueIfRequired(prevProps: Object) {
     const {props, state, focusedElm} = this;
     const {value: stateValue, numAsString: lastNumStr = ''} = state;

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -136,6 +136,7 @@ class NumberFormat extends React.Component {
   componentWillUnmount() {
     if (this.focusTimeout != null) {
       clearTimeout(this.focusTimeout);
+      this.focusTimeout = undefined;
     }
   }
 
@@ -761,6 +762,7 @@ class NumberFormat extends React.Component {
     this.focusedElm = null;
     if (this.focusTimeout){
       clearTimeout(this.focusTimeout);
+      this.focusTimeout = undefined;
     }
 
 

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -342,6 +342,26 @@ describe('Test keypress and caret position changes', () => {
       jasmine.clock().uninstall()
     });
 
+    it('should clear active timers', () => {
+      jasmine.clock().install();
+      const spy = spyOn(console, 'error');
+
+      const wrapper = mount(<NumberFormat />);
+      const instance = wrapper.instance();
+
+      simulateFocusEvent(wrapper.find('input'), 0, 0, setSelectionRange);
+
+      expect(instance.focusTimeout).toBeTruthy();
+
+      wrapper.unmount();
+      jasmine.clock().tick(1);
+
+      expect(instance.focusTimeout).toBeFalsy();
+
+      spy.calls.reset();
+      jasmine.clock().uninstall();
+    });
+
     it('should correct wrong caret positon on focus when allowEmptyFormatting is set', () => {
       jasmine.clock().install()
       const wrapper = shallow(<NumberFormat format="+1 (###) ### # ## US" allowEmptyFormatting={true} value="" mask="_"/>);

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -344,7 +344,6 @@ describe('Test keypress and caret position changes', () => {
 
     it('should clear active timers', () => {
       jasmine.clock().install();
-      const spy = spyOn(console, 'error');
 
       const wrapper = mount(<NumberFormat />);
       const instance = wrapper.instance();
@@ -358,7 +357,6 @@ describe('Test keypress and caret position changes', () => {
 
       expect(instance.focusTimeout).toBeFalsy();
 
-      spy.calls.reset();
       jasmine.clock().uninstall();
     });
 

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -290,6 +290,10 @@ describe('Test keypress and caret position changes', () => {
 
   describe('Test click / focus on input', () => {
 
+    afterEach(() => {
+      jasmine.clock().uninstall()
+    });
+
     it('should always keep caret on typable area when we click on the input', () => {
       const wrapper = shallow(<NumberFormat  format="+1 (###) ### # ## US" value="+1 (123) 456 7 89 US"/>);
 
@@ -344,20 +348,15 @@ describe('Test keypress and caret position changes', () => {
 
     it('should clear active timers', () => {
       jasmine.clock().install();
-
-      const wrapper = mount(<NumberFormat />);
-      const instance = wrapper.instance();
+      const onFocus = jasmine.createSpy();
+      const wrapper = mount(<NumberFormat onFocus={onFocus} />);
 
       simulateFocusEvent(wrapper.find('input'), 0, 0, setSelectionRange);
-
-      expect(instance.focusTimeout).toBeTruthy();
 
       wrapper.unmount();
       jasmine.clock().tick(1);
 
-      expect(instance.focusTimeout).toBeFalsy();
-
-      jasmine.clock().uninstall();
+      expect(onFocus).toHaveBeenCalledTimes(0);
     });
 
     it('should correct wrong caret positon on focus when allowEmptyFormatting is set', () => {


### PR DESCRIPTION
`onFocus` is handled asynchronously with setTimeout. When testing inputs with react-number-format, it prints a warning saying it is updating the unmounted component.

Clear focusTimeout on unmount.
