### PR TITLE
Added string[] and readonly string[] for NumberFormatProps for defaultValue

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -39,7 +39,7 @@ declare module "react-number-format" {
     removeFormatting?: (formattedValue: string) => string;
     mask?: string | string[];
     value?: number | string;
-    defaultValue?: number | string;
+    defaultValue?: number | string | readonly string[];
     isNumericString?: boolean;
     customInput?: React.ComponentType<any>;
     allowNegative?: boolean;

--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -39,7 +39,7 @@ declare module "react-number-format" {
     removeFormatting?: (formattedValue: string) => string;
     mask?: string | string[];
     value?: number | string;
-    defaultValue?: number | string | readonly string[];
+    defaultValue?: number | string | string[] | readonly string[];
     isNumericString?: boolean;
     customInput?: React.ComponentType<any>;
     allowNegative?: boolean;


### PR DESCRIPTION
This PR try to fix a type error of `NumberFormatProps` when using the MaterialUi Textfield `inputComponent` in `InputProps`

Failing example:
https://codesandbox.io/s/wonderful-chaplygin-f3otf
If you go to the component `MyInput` you can see that the component `NumberFormatCustom` takes `NumberFormatProps` as props.
The Material UI Textfied, in its  `InputProps`, can take a `inputComponent` which can be the `NumberFormatCustom` component.
This leads to a type error since the props Textfied's `defaultValue` types are: `any` (https://material-ui.com/api/text-field/)
while the NumberFormatProps's defaultValue is defined as: `string | number | undefined`.

I tried to extend the types of `defaultValue` by including `string[]` and `readonly string[]` which seem to solve the above mentioned error