### PR TITLE
Fix full value replacement issue when allowEmptyString is set to true 

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -651,7 +651,7 @@ class NumberFormat extends React.Component {
       value.length > lastValue.length
       || !value.length ||
       start === end ||
-      (selectionStart === 0 && selectionEnd === lastValue.length) ||
+      (start === 0 && end === lastValue.length) ||
       (selectionStart === leftBound && selectionEnd === rightBound)
     ) {
       return value;

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -8,6 +8,7 @@ import {
   simulateKeyInput,
   simulateFocusEvent,
   simulateBlurEvent,
+  getCustomEvent,
   shallow,
   mount
 } from '../test_util';
@@ -225,6 +226,14 @@ describe('NumberFormat as input', () => {
     wrapper.setProps({value: '+1 (777) 777 7 77 US'});
     simulateKeyInput(wrapper.find('input'), '8', 8, 9);
     expect(wrapper.state().value).toEqual('+1 (777) 777 7 77 US');
+  });
+
+  it('should update value if whole content is replaced by new number', () => {
+    const wrapper = shallow(<NumberFormat format="+1 (###) ### # ## US" allowEmptyFormatting/>);
+
+    wrapper.find('input').simulate('change', getCustomEvent('012345678', 20, 20));
+
+    expect(wrapper.find('input').prop('value')).toEqual('+1 (012) 345 6 78 US');
   });
 
   it('should allow replacing all characters with number when formatting is present', () => {


### PR DESCRIPTION
#### Describe the issue/change
When the input gets value via the auto-complete feature of a browser and is `allowEmptyFormatting` is allowed, it does not show the updated value and shows the old formatted string.

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)
Browser autocomplete replacing the whole value will not update the input field with the new value

#### Describe the changes proposed/implemented in this PR
The logic looks to validate if the selection is for the entire string and updates the value 

#### Link Github issue if this PR solved an existing issue
#450 

#### Example usage (If applicable)
No change in the usage

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
