### PR TITLE
fix: add type number for html type atribute

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -54,7 +54,7 @@ declare module "react-number-format" {
      * onFocus: Function;
      * onBlur: Function;
      */
-    type?: 'text' | 'tel'  | 'password';
+    type?: 'text' | 'tel'  | 'password' | 'number';
     isAllowed?: (values: NumberFormatValues) => boolean;
     renderText?: (formattedValue: string) => React.ReactNode;
     getInputRef?: ((el: HTMLInputElement) => void) | React.Ref<any>;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number

My end proposal is to use just string as the type definition for, but I added this pull just adding number as an minimal change.

#### Describe the issue/change

Typescript releatable: 
When I use the prop type number on the NumberFormat component I got a type error allowing just text | tel | undefined, this is a minimal change to accept the number on type prop as well.
 You guys can just use as string to accept any string pass thought if this lib is just using this props to inject into the dom element.

#### Add CodeSandbox link to illustrate the issue (If applicable)
No applicable
#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [ ] Chrome
- [x] Chrome (Android)
- [x] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
