### PR TITLE
fix: input refocused after blur

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -89,6 +89,7 @@ class NumberFormat extends React.Component {
   onFocus: Function;
   onBlur: Function;
   focusTimeout: number;
+  caretPositionTimeout: number;
   focusedElm: HTMLElement;
   selectionBeforeInput: {
     selectionStart: number,
@@ -137,6 +138,7 @@ class NumberFormat extends React.Component {
 
   componentWillUnmount() {
     clearTimeout(this.focusTimeout);
+    clearTimeout(this.caretPositionTimeout);
   }
 
   updateValueIfRequired(prevProps: Object) {
@@ -283,7 +285,7 @@ class NumberFormat extends React.Component {
     otherwise browser resets the caret position after we set it
     We are also setting it without timeout so that in normal browser we don't see the flickering */
     setCaretPosition(el, caretPos);
-    setTimeout(() => {
+    this.caretPositionTimeout = setTimeout(() => {
       if (el.value === currentValue) setCaretPosition(el, caretPos);
     }, 0);
   }
@@ -821,6 +823,7 @@ class NumberFormat extends React.Component {
     this.focusedElm = null;
 
     clearTimeout(this.focusTimeout);
+    clearTimeout(this.caretPositionTimeout);
 
     if (!format) {
       // if the numAsString is not a valid number reset it to empty


### PR DESCRIPTION
#### Describe the issue/change
In a huge app (my application has some 40+ controls and form management is done using Formik) and type some data in the react-number-format control and hit 'tab'/ go to some other control, then the focus goes back to the previous control this can be seen by entering a huge huge number in the example or a very small number in the huge app.

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

Debugged the issue and it narrowed down this line where the setTimeout execution was late so clearing this on blur and on unmount of the component to avoid a memory leak.

#### Link Github issue if this PR solved an existing issue
There was no such issue raised

#### Example usage (If applicable)
Type a huge huge number in the example app and hit 'tab' to observe the issue

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [x] Chrome
- [x] Firefox
- [ ] Firefox (Android)
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
