### PR TITLE
Align Docs Is Allowed Example With Type Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ function cardExpiry(val) {
   <NumberFormat value={12} isAllowed={withValueLimit} />;
 ```
 
+We are using `floatValue` here because it provides the exact value (see [values object](#values-object)). `value` is rounded to your configured `decimalScale`; hence it may omit a part of the precision of the actual value. Given an entered value of 1400.4 and the default `decimalScale`, `value` would be transferred as 1400 in the values object and pass the above `withValueLimit` check. In this case, it is a false positive that can be prevented using `floatValue`. However, you might want to use `value` to automatically get the rounded number according to your `decimalScale`.
+
 Visit this link for Demo: [Field with value limit](https://codesandbox.io/s/react-number-format-isallowed-8gu0v)
 
 ![Screencast example](https://media.giphy.com/media/7agdv1sb9JYJEYlN3s/giphy.gif)

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ function cardExpiry(val) {
   const MAX_VAL = 1400;
   const withValueLimit = (inputObj) => {
     const { value } = inputObj;
-    if (value < MAX_VAL) return inputObj;
+    if (value >= MAX_VAL) return false;
+    return true;
   };
   <NumberFormat value={12} isAllowed={withValueLimit} />;
 ```

--- a/README.md
+++ b/README.md
@@ -207,11 +207,7 @@ function cardExpiry(val) {
 ### Limit input value to a maximum limit
 ```jsx
   const MAX_VAL = 1400;
-  const withValueLimit = (inputObj) => {
-    const { value } = inputObj;
-    if (value >= MAX_VAL) return false;
-    return true;
-  };
+  const withValueLimit = ({ floatValue }) => floatValue <= 1400;
   <NumberFormat value={12} isAllowed={withValueLimit} />;
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ function cardExpiry(val) {
 ### Limit input value to a maximum limit
 ```jsx
   const MAX_VAL = 1400;
-  const withValueLimit = ({ floatValue }) => floatValue <= 1400;
+  const withValueLimit = ({ floatValue }) => floatValue <= MAX_VAL;
   <NumberFormat value={12} isAllowed={withValueLimit} />;
 ```
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ function cardExpiry(val) {
   <NumberFormat value={12} isAllowed={withValueLimit} />;
 ```
 
-We are using `floatValue` here because it provides the exact value (see [values object](#values-object)). `value` is rounded to your configured `decimalScale`; hence it may omit a part of the precision of the actual value. Given an entered value of 1400.4 and the default `decimalScale`, `value` would be transferred as 1400 in the values object and pass the above `withValueLimit` check. In this case, it is a false positive that can be prevented using `floatValue`. However, you might want to use `value` to automatically get the rounded number according to your `decimalScale`.
+It is sensible to use `floatValue` in the `withValueLimit` check because it provides the exact value (see [values object](#values-object)). `value` is rounded to your configured `decimalScale`; hence it may omit a part of the precision of the actual value. Given an entered value of 1400.4 and the default `decimalScale`, `value` would be transferred as 1400 in the values object and pass the above `withValueLimit` check. In this case, it is a false positive that can be prevented using `floatValue`. However, you might want to use `value` to automatically get the rounded number according to your `decimalScale`.
 
 Visit this link for Demo: [Field with value limit](https://codesandbox.io/s/react-number-format-isallowed-8gu0v)
 


### PR DESCRIPTION
#### Describe the issue/change

The [docs](https://github.com/s-yadav/react-number-format/blob/master/README.md) show a wrong example of the `isAllowed` callback. It returns the `inputObj` if it passes the check or `undefined`. This actually works in JavaScript because of type coercion (IMO still a bad practice). However, in TypeScript the type definition enforces a `boolean` to be returned.

```javascript
const MAX_VAL = 1400;
const withValueLimit = (inputObj) => {
  const { value } = inputObj;
  if (value < MAX_VAL) return inputObj;
};
<NumberFormat value={12} isAllowed={withValueLimit} />;
```

The [type definition](https://github.com/s-yadav/react-number-format/blob/master/typings/number_format.d.ts) requires a `boolean`:
```typescript
isAllowed?: (values: NumberFormatValues) => boolean;
```

#### Describe the changes proposed/implemented in this PR

Aligned the `isAllowed` example in the docs with the method's type definition.