### PR TITLE
Fix issue #533

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-number-format",
   "description": "React component to format number in an input or as a text.",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "main": "dist/react-number-format.cjs.js",
   "module": "dist/react-number-format.es.js",
   "author": "Sudhanshu Yadav",

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,6 +134,15 @@ export function toNumericString(num) {
   return sign + coefficient;
 }
 
+export function containsAllZeros(numStr: string) {
+  for (let i = 0; i <= numStr.length - 1; i++) {
+    if (numStr[i] !== '0') {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * This method is required to round prop value to given scale.
  * Not used .round or .fixedTo because that will break with big numbers
@@ -161,8 +170,9 @@ export function roundToPrecision(numStr: string, scale: number, fixedDecimalScal
       return current + roundedStr;
     }, roundedDecimalParts[0]);
 
+  const inputDecimal = containsAllZeros(afterDecimal) ? afterDecimal : roundedDecimalParts[1] || '';
   const decimalPart = limitToScale(
-    roundedDecimalParts[1] || '',
+    inputDecimal,
     Math.min(scale, afterDecimal.length),
     fixedDecimalScale,
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,15 +134,6 @@ export function toNumericString(num) {
   return sign + coefficient;
 }
 
-export function containsAllZeros(numStr: string) {
-  for (let i = 0; i <= numStr.length - 1; i++) {
-    if (numStr[i] !== '0') {
-      return false;
-    }
-  }
-  return true;
-}
-
 /**
  * This method is required to round prop value to given scale.
  * Not used .round or .fixedTo because that will break with big numbers
@@ -155,7 +146,7 @@ export function roundToPrecision(numStr: string, scale: number, fixedDecimalScal
   const { beforeDecimal, afterDecimal, hasNagation } = splitDecimal(numStr);
   const floatValue = parseFloat(`0.${afterDecimal || '0'}`);
   const floatValueStr =
-    afterDecimal.length <= scale ? toNumericString(floatValue) : floatValue.toFixed(scale);
+    afterDecimal.length <= scale ? `0.${afterDecimal}` : floatValue.toFixed(scale);
   const roundedDecimalParts = floatValueStr.split('.');
   const intPart = beforeDecimal
     .split('')
@@ -170,9 +161,8 @@ export function roundToPrecision(numStr: string, scale: number, fixedDecimalScal
       return current + roundedStr;
     }, roundedDecimalParts[0]);
 
-  const inputDecimal = containsAllZeros(afterDecimal) ? afterDecimal : roundedDecimalParts[1] || '';
   const decimalPart = limitToScale(
-    inputDecimal,
+    roundedDecimalParts[1] || '',
     Math.min(scale, afterDecimal.length),
     fixedDecimalScale,
   );

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -554,8 +554,10 @@ describe('NumberFormat as input', () => {
       expect(wrapper.find('input').instance().value).toEqual('$100.0');
       wrapper.setState({ value: '123.00' });
       expect(wrapper.find('input').instance().value).toEqual('$123.00');
-      wrapper.setState({ value: '100.000' });
-      expect(wrapper.find('input').instance().value).toEqual('$100.00');
+      wrapper.setState({ value: '132.000' });
+      expect(wrapper.find('input').instance().value).toEqual('$132.00');
+      wrapper.setState({ value: '100.10' });
+      expect(wrapper.find('input').instance().value).toEqual('$100.10');
     });
   });
 });

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -492,6 +492,7 @@ describe('NumberFormat as input', () => {
       }).toThrow();
     });
 
+    // Test case for Issue #533
     it('should show the right decimal values based on the decimal scale provided', () => {
       class WrapperComponent extends React.Component {
         constructor() {

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -219,7 +219,9 @@ describe('NumberFormat as input', () => {
   });
 
   it('should update value if group of characters got deleted with format', () => {
-    const wrapper = shallow(<NumberFormat format="+1 (###) ### # ## US" value="+1 (999) 999 9 99 US"/>);
+    const wrapper = shallow(
+      <NumberFormat format="+1 (###) ### # ## US" value="+1 (999) 999 9 99 US" />,
+    );
     simulateKeyInput(wrapper.find('input'), 'Backspace', 6, 10);
     expect(wrapper.state().value).toEqual('+1 (999) 999 9    US');
 
@@ -227,13 +229,13 @@ describe('NumberFormat as input', () => {
     wrapper.setProps({ value: '+1 (888) 888 8 88 US' });
     simulateKeyInput(wrapper.find('input'), '8', 6, 10);
     expect(wrapper.state().value).toEqual('+1 (888) 888 8 8  US');
-  })
+  });
 
   it('should maintain the format even when the format is numeric and characters are deleted', () => {
-    const wrapper = shallow(<NumberFormat format="0###0 ###0####" value="01230 45607899"/>);
+    const wrapper = shallow(<NumberFormat format="0###0 ###0####" value="01230 45607899" />);
     simulateKeyInput(wrapper.find('input'), 'Backspace', 6, 10);
     expect(wrapper.state().value).toEqual('01230 78909   ');
-  })
+  });
 
   it('should update value if whole content is replaced by new number', () => {
     const wrapper = shallow(<NumberFormat format="+1 (###) ### # ## US" allowEmptyFormatting />);
@@ -523,6 +525,37 @@ describe('NumberFormat as input', () => {
       expect(wrapper.find('input').instance().value).toEqual('$123.123');
       wrapper.setState({ value: '123.1234' });
       expect(wrapper.find('input').instance().value).toEqual('$123.1234');
+    });
+
+    it('should show the right number of zeros in all cases', () => {
+      class WrapperComponent extends React.Component {
+        constructor() {
+          super();
+          this.state = {
+            value: '100.0',
+          };
+        }
+
+        render() {
+          return (
+            <NumberFormat
+              name="numberformat"
+              value={this.state.value}
+              thousandSeparator
+              prefix="$"
+              decimalScale={2}
+              isNumericString
+            />
+          );
+        }
+      }
+
+      const wrapper = mount(<WrapperComponent />);
+      expect(wrapper.find('input').instance().value).toEqual('$100.0');
+      wrapper.setState({ value: '123.00' });
+      expect(wrapper.find('input').instance().value).toEqual('$123.00');
+      wrapper.setState({ value: '100.000' });
+      expect(wrapper.find('input').instance().value).toEqual('$100.00');
     });
   });
 });


### PR DESCRIPTION
#### Describe the issue/change
This fixes the trailing zeros issue when an input like `###.00` is provided

#### Add CodeSandbox link to illustrate the issue (If applicable)
N/A

#### Describe specs for failing cases if this is an issue (If applicable)
- Should show the right number of zeros in all cases based on the `decimalScale` provided

#### Describe the changes proposed/implemented in this PR
- Adds a function to identify if the string is all zeros
- Uses that conditionally to pass the value to `limitToScale`

#### Link Github issue if this PR solved an existing issue
Issue: #533 

#### Example usage (If applicable)
```
<NumberFormat
        name={"AmountCents"}
        value={"100.00"}
        thousandSeparator
        prefix="$"
        decimalScale={2}
        isNumericString
      />
```

Output: 100.00

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
