### PR TITLE
add support for paste event given allowedDecimalSeparators

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -114,6 +114,16 @@ class App extends React.Component {
         </div>
 
         <div className="example">
+          <h3>Custom allowed decimal separators with decimal precision</h3>
+          <NumberFormat
+            thousandSeparator={' '}
+            allowedDecimalSeparators={['.', ',']}
+            decimalSeparator='.'
+            decimalScale={2}
+          />
+        </div>
+
+        <div className="example">
           <h3>Format with pattern : Format credit card in an input</h3>
           <NumberFormat format="#### #### #### ####" mask="_" />
         </div>

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -671,6 +671,16 @@ class NumberFormat extends React.Component {
       );
     }
 
+    /** Check for "paste event" with, replace any allowed decimal separator with desired decimal separator */
+    if (!format && decimalScale !== 0 && allowedDecimalSeparators.some(separator => value.indexOf(separator) !== -1)) {
+      const separator = decimalScale === 0 ? '' : decimalSeparator
+      let result = value;
+      allowedDecimalSeparators.forEach(v => {
+        result = result.replace(v, separator);
+      })
+      value = result;
+    }
+
     const leftBound = !!format ? 0 : prefix.length;
     const rightBound = lastValue.length - (!!format ? 0 : suffix.length);
 

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -603,6 +603,22 @@ describe('Test NumberFormat as input with numeric format options', () => {
     expect(wrapper.state().value).toEqual('23,4456 Sq. ft');
   });
 
+
+  it('should allow pasting 123,45 with decimal separator set to . and allowedDecimalSeparators=["," , "."]', () => {
+    const wrapper = shallow(
+      <NumberFormat
+        displayType="input"
+        thousandSeparator={' '}
+        prefix=""
+        allowedDecimalSeparators={['.', ',']}
+        decimalSeparator='.'
+        decimalScale={2}
+      />,
+    );
+    simulateKeyInput(wrapper.find('input'), '123,45');
+    expect(wrapper.state().value).toEqual('123.45');
+  });
+
   it('should not break if suffix/prefix has negation sign. Issue #245', () => {
     const wrapper = shallow(<NumberFormat suffix="-" />);
 


### PR DESCRIPTION
#### Describe the issue/change
Described here https://github.com/s-yadav/react-number-format/issues/349 by @tenkij
#### Add CodeSandbox link to illustrate the issue (If applicable)
[Codesandbox by @tenkij](https://codesandbox.io/s/react-number-format-demo-f7245)
#### Describe specs for failing cases if this is an issue (If applicable)
allowedDecimalSeparators={[",", "."]}

decimalSeparator='.'

1. paste '11.11', result '11.11';
2. paste '11,11', result '1 111'

decimalSeparator=','

1. paste '11.11', result '1 111';
2.  paste '11,11', result '11,11'

#### Describe the changes proposed/implemented in this PR
Now the paste works with both cases

https://user-images.githubusercontent.com/9840635/123081289-1a488600-d41e-11eb-8a97-002850e185bd.mp4

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
