### PR TITLE
feat: added custom numeral support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In typescript you also have to enable `"esModuleInterop": true` in your tsconfig
 | renderText | (formattedValue, customProps) => React Element | null | A renderText method useful if you want to render formattedValue in different element other than span. It also returns the custom props that are added to the component which can allow passing down props to the rendered element |
 | getInputRef | (elm) => void | null | Method to get reference of input, span (based on displayType prop) or the customInput's reference. See [Getting reference](#getting-reference)
 | allowedDecimalSeparators | array of char | none | Characters which when pressed result in a decimal separator. When missing, decimal separator and '.' are used |
-| customNumerals | array of string | none | an array of 10 strings with represent numerals in different locales. ranging from 0 - 9. the result will be converted to english numeral and treated as number |
+| customNumerals | array of string | none | an array of 10 single-character strings with represent numerals in different locales. ranging from 0 - 9. the result will be converted to english numeral and treated as number |
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ In typescript you also have to enable `"esModuleInterop": true` in your tsconfig
 | renderText | (formattedValue, customProps) => React Element | null | A renderText method useful if you want to render formattedValue in different element other than span. It also returns the custom props that are added to the component which can allow passing down props to the rendered element |
 | getInputRef | (elm) => void | null | Method to get reference of input, span (based on displayType prop) or the customInput's reference. See [Getting reference](#getting-reference)
 | allowedDecimalSeparators | array of char | none | Characters which when pressed result in a decimal separator. When missing, decimal separator and '.' are used |
+| customNumerals | array of string | none | an array of 10 strings with represent numerals in different locales. ranging from 0 - 9. the result will be converted to english numeral and treated as number |
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**
 
@@ -211,6 +212,12 @@ function cardExpiry(val) {
   <NumberFormat value={12} isAllowed={withValueLimit} />;
 ```
 
+### Custom Numeral
+```jsx
+  const persianNumeral = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']
+  <NumberFormat customNumerals={persianNumeral} />;
+```
+
 It is sensible to use `floatValue` in the `withValueLimit` check because it provides the exact value (see [values object](#values-object)). `value` is rounded to your configured `decimalScale`; hence it may omit a part of the precision of the actual value. Given an entered value of 1400.4 and the default `decimalScale`, `value` would be transferred as 1400 in the values object and pass the above `withValueLimit` check. In this case, it is a false positive that can be prevented using `floatValue`. However, you might want to use `value` to automatically get the rounded number according to your `decimalScale`.
 
 Visit this link for Demo: [Field with value limit](https://codesandbox.io/s/react-number-format-isallowed-8gu0v)
@@ -239,6 +246,7 @@ All custom input props and number input props are passed together.
 ```jsx
   <NumberFormat hintText="Some placeholder" value={this.state.card} customInput={TextField} format="#### #### #### ####"/>
 ```
+
 
 ### Getting reference
 As `ref` is a special property in react, its not passed as props. If you add ref property it will give you the reference of NumberFormat instance. In case you need input reference. You can use getInputRef prop instead.

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -147,6 +147,11 @@ class App extends React.Component {
           <h3>Custom input : Format credit card number</h3>
           <NumberFormat customInput={TextField} format="#### #### #### ####" />
         </div>
+
+        <div className="example">
+          <h3>Custom Numeral: add support for custom languages </h3>
+          <NumberFormat customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} />
+        </div>
       </div>
     );
   }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -60,7 +60,7 @@ const propTypes = {
       return;
     }
     const arrayPropLength = props[propName].length;
-    const itemsAreString = props[propName].every((item) => typeof item === 'string');
+    const hasSingleCharString = props[propName].every((item) => typeof item === 'string' && item.length === 1);
     if (arrayPropLength !== 10) {
       return new Error(
         `Invalid array length ${arrayPropLength} (expected ${10}) for prop ${propName} supplied to ${componentName}. Validation failed.`,

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -55,7 +55,23 @@ const propTypes = {
     PropTypes.func, // for legacy refs
     PropTypes.shape({ current: PropTypes.any }),
   ]),
-  customNumerals: PropTypes.arrayOf(PropTypes.string),
+  customNumerals: (props, propName, componentName) => {
+    if (!props[propName]) {
+      return;
+    }
+    const arrayPropLength = props[propName].length;
+    const itemsAreString = props[propName].every((item) => typeof item === 'string');
+    if (arrayPropLength !== 10) {
+      return new Error(
+        `Invalid array length ${arrayPropLength} (expected ${10}) for prop ${propName} supplied to ${componentName}. Validation failed.`,
+      );
+    }
+    if (!itemsAreString) {
+      return new Error(
+        `Invalid element type for prop ${propName} supplied to ${componentName}. all provided elements in the array must be string. Validation failed.`,
+      );
+    }
+  },
 };
 
 const defaultProps = {

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -21,6 +21,15 @@ describe('NumberFormat as input', () => {
     });
   });
 
+  it('should accept and format custom numerals', () => {
+    const wrapper = mount(
+      <NumberFormat customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} />,
+    );
+    simulateKeyInput(wrapper.find('input'), '۱۲۳۴۵۶۷۸۹۰', 0);
+
+    expect(wrapper.state().value).toEqual('1234567890');
+  });
+
   it('should render input as type text by default', () => {
     const wrapper = mount(<NumberFormat />);
     expect(wrapper.find('input').instance().getAttribute('type')).toEqual('text');

--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -56,6 +56,18 @@ declare module 'react-number-format' {
     renderText?: (formattedValue: string) => React.ReactNode;
     getInputRef?: ((el: HTMLInputElement) => void) | React.Ref<any>;
     allowedDecimalSeparators?: Array<string>;
+    customNumerals: [
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+    ];
   }
 
   // The index signature allows any prop to be passed in, such as if wanting to send props


### PR DESCRIPTION
#### Describe the issue/change

added support for Custom numeral which automatically formats it to standard English numeral based on suggestion made on my [previous pull request](https://github.com/s-yadav/react-number-format/pull/535#issuecomment-849824452) 

#### Describe the changes proposed/implemented in this PR

added an optional prop customNumerals which accepts an array of custom numbers ranging from 0 to 9,
eg: customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} which is persian numeral for 0-9

#### Please check which browsers were used for testing
- [ x] Chrome
- [ x] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [x ] Firefox
- [ ] Firefox (Android)
