### PR TITLE
fix: fixed SSR issue (w/ navigator) when using together with @react-pdf/renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ node_modules/**/*
 .cache
 tmp
 
-./dist
-./lib
+dist
+lib

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Feature Addition
 - Clone the repository or download the zip
 - `npm i -g yarn` to download Yarn
 - `yarn` to install dependencies
-- `yarn start` to run example server
+- `yarn start` to run example server (<http://localhost:8084/>)
 - `yarn test` to test changes
 - `yarn bundle` to bundle files
 

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -694,34 +694,33 @@ class NumberFormat extends React.Component {
 
     // check whether the deleted portion has a character that is part of a format
     const deletedValues = lastValue.substr(start, end - start);
-    const formatGotDeleted = !![...deletedValues].find((deletedVal, idx) => this.isCharacterAFormat(idx + start, lastValue));
+    const formatGotDeleted = !![...deletedValues].find((deletedVal, idx) =>
+      this.isCharacterAFormat(idx + start, lastValue),
+    );
 
     // if it has, only remove characters that are not part of the format
-    if(formatGotDeleted) {
-      const deletedValuePortion = lastValue.substr(start)
+    if (formatGotDeleted) {
+      const deletedValuePortion = lastValue.substr(start);
       const recordIndexOfFormatCharacters = {};
       const resolvedPortion = [];
       [...deletedValuePortion].forEach((currentPortion, idx) => {
-        if(this.isCharacterAFormat(idx + start, lastValue)){
+        if (this.isCharacterAFormat(idx + start, lastValue)) {
           recordIndexOfFormatCharacters[idx] = currentPortion;
         } else if (idx > deletedValues.length - 1) {
           resolvedPortion.push(currentPortion);
         }
-      })
+      });
 
-      Object.keys(recordIndexOfFormatCharacters).forEach(idx => {
-        if(resolvedPortion.length > idx){
+      Object.keys(recordIndexOfFormatCharacters).forEach((idx) => {
+        if (resolvedPortion.length > idx) {
           resolvedPortion.splice(idx, 0, recordIndexOfFormatCharacters[idx]);
         } else {
-          resolvedPortion.push(recordIndexOfFormatCharacters[idx])
+          resolvedPortion.push(recordIndexOfFormatCharacters[idx]);
         }
-      })
+      });
 
       value = lastValue.substr(0, start) + resolvedPortion.join('');
     }
-
-
-
 
     //for numbers check if beforeDecimal got deleted and there is nothing after decimal,
     //clear all numbers in such case while keeping the - sign

--- a/src/utils.js
+++ b/src/utils.js
@@ -243,5 +243,9 @@ export function getCurrentCaretPosition(el: HTMLInputElement) {
 }
 
 export function addInputMode(format: string | FormatInputValueFunction) {
-  return format || !(navigator.platform && /iPhone|iPod/.test(navigator.platform));
+  return (
+    format ||
+    (typeof navigator !== 'undefined' &&
+      !(navigator.platform && /iPhone|iPod/.test(navigator.platform)))
+  );
 }


### PR DESCRIPTION
#### Describe the issue/change

The issue https://github.com/s-yadav/react-number-format/issues/481 was not properly resolved with [this change](https://github.com/s-yadav/react-number-format/blame/14208b6e71d0c3e36a13415a073d3a08f0ea1318/src/number_format.js#L1011
). The error still exists when using `NumberFormat` on the server.

PS: can we merge and deploy this please as soon as possible? This is a release blocker for us at the moment. Thanks for your help. Let me know what it takes to get this done anytime.

#### Add CodeSandbox link to illustrate the issue (If applicable)

I do not have one, sorry.

#### Describe specs for failing cases if this is an issue (If applicable)

Use `NumberFormat` on the server.

#### Describe the changes proposed/implemented in this PR

Tests the `typeof navigator` which ensures the code will not fail on the server. The current check did catch all cases.

--> see https://github.com/s-yadav/react-number-format/pull/560/commits/b0735ef75e8517dc476795f71d5992485e95721e

#### Link Github issue if this PR solved an existing issue

resolves https://github.com/s-yadav/react-number-format/issues/481

#### Example usage (If applicable)

I use `NumberFormat` on the server when generating PDFs with https://react-pdf.org/.

#### Screenshot (If applicable)

Not necessary in my opinion.

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [x] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
