### PR TITLE
feat: make typings for customInput generic

### DIFF
--- a/typings/number_format.d.ts
+++ b/typings/number_format.d.ts
@@ -23,7 +23,7 @@ declare module 'react-number-format' {
     data: any;
   }
 
-  export interface NumberFormatPropsBase extends InputAttributes {
+  export type NumberFormatPropsBase<T> = {
     thousandSeparator?: boolean | string;
     decimalSeparator?: string;
     thousandsGroupStyle?: 'thousand' | 'lakh' | 'wan';
@@ -38,7 +38,7 @@ declare module 'react-number-format' {
     value?: number | string | null;
     defaultValue?: number | string;
     isNumericString?: boolean;
-    customInput?: React.ComponentType<any>;
+    customInput?: React.ComponentType<T>;
     allowNegative?: boolean;
     allowEmptyFormatting?: boolean;
     allowLeadingZeros?: boolean;
@@ -70,13 +70,8 @@ declare module 'react-number-format' {
     ];
   }
 
-  // The index signature allows any prop to be passed in, such as if wanting to send props
-  // to a customInput. We export this as a separate interface to allow client authors to
-  // choose the stricter typing of NumberFormatPropsBase if desired.
-  export interface NumberFormatProps extends NumberFormatPropsBase {
-    [key: string]: any;
-  }
+  export type NumberFormatProps<T> = NumberFormatPropsBase<T> & Omit<T, keyof NumberFormatPropsBase<unknown> | 'ref'>
 
-  class NumberFormat extends React.Component<NumberFormatProps, any> {}
+  class NumberFormat<T = InputAttributes> extends React.Component<NumberFormatProps<T>, any> {}
   export default NumberFormat;
 }

--- a/typings/number_format.spec.tsx
+++ b/typings/number_format.spec.tsx
@@ -3,4 +3,5 @@ import { default as NumberFormat } from 'react-number-format';
 
 <NumberFormat value="" />;
 <NumberFormat type="tel" />;
-<NumberFormat type="tel" readOnly={false} />;
+<NumberFormat type="tel" readOnly={false} size={1} />;
+<NumberFormat customInput={(props: { size: "small" | "large" }) => <></>} type="tel" size="small" />;


### PR DESCRIPTION
#### Describe the issue/change

We are using react-number-format together with material-ui. In our case we want to use the custumInput "TextField" but pass the prop: `{ size: "small" }`.

When we do this we get the error:

```
No overload matches this call.
  Overload 1 of 2, '(props: NumberFormatProps | Readonly<NumberFormatProps>): NumberFormat', gave the following error.
    Type 'string' is not assignable to type 'number | undefined'.
  Overload 2 of 2, '(props: NumberFormatProps, context: any): NumberFormat', gave the following error.
    Type 'string' is not assignable to type 'number | undefined'.ts(2769)
```

The problem here is, that `NumberFormatProps` are typed to always extend `InputAttributes`. Where actually when we use a customInput there is no reason to pass `InputAttributes`. In that case we should be able to pass the props of the customInput.

As far as I understand this is how the actual logic works.

#### Add CodeSandbox link to illustrate the issue (If applicable)

https://codesandbox.io/s/beautiful-tess-eb5r6?file=/src/App.tsx

#### Describe the changes proposed/implemented in this PR

I updated the typings of NumberFormatProps to be generic. Now instead of always extending from `InputAttributes` the Props-Type of the component passed as customInput are extracted and added to the typing. Typescript is actually smart enought to this automatically. 

I must say that I can not promise this does not introduce breaking changes for people that import and use the current typings. But in my opinion those generic typings are closer to how the component actually works.

#### Link Github issue if this PR solved an existing issue

#422

#### Example usage (If applicable)

See the updated typings/number_format.spec.tsx https://github.com/s-yadav/react-number-format/commit/c9e06279aa1fc9fac5b35930de08d508ada6de74#diff-9d8e8f0103177d8c0688a00a41889511f17c18bfa6150b4d4922aa40fc87825aR7
