### PR TITLE
fix: get correct regular expression to sharing 'format' and 'customNumerals' props

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -426,7 +426,7 @@ class NumberFormat extends React.Component {
       }
     }
 
-    return (numStr.match(/\d/g) || []).join('');
+    return (numStr.match(this.getNumberRegex(true)) || []).join('');
   }
 
   removeFormatting(val: string) {
@@ -442,7 +442,7 @@ class NumberFormat extends React.Component {
       //condition need to be handled if format method is provide,
       val = removeFormatting(val);
     } else {
-      val = (val.match(/\d/g) || []).join('');
+      val = (val.match(this.getNumberRegex(true)) || []).join('');
     }
     return val;
   }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -471,8 +471,14 @@ class NumberFormat extends React.Component {
    * @return {string} formatted Value
    */
   formatAsNumber(numStr: string) {
-    const { decimalScale, fixedDecimalScale, prefix, suffix, allowNegative, thousandsGroupStyle } =
-      this.props;
+    const {
+      decimalScale,
+      fixedDecimalScale,
+      prefix,
+      suffix,
+      allowNegative,
+      thousandsGroupStyle,
+    } = this.props;
     const { thousandSeparator, decimalSeparator } = this.getSeparators();
 
     const hasDecimalSeparator = numStr.indexOf('.') !== -1 || (decimalScale && fixedDecimalScale);

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -30,6 +30,18 @@ describe('NumberFormat as input', () => {
     expect(wrapper.state().value).toEqual('1234567890');
   });
 
+  it('should accept and format custom numerals together with format input field', () => {
+    const wrapper = mount(
+      <NumberFormat
+        customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']}
+        format="##########"
+      />,
+    );
+    simulateKeyInput(wrapper.find('input'), '۱۲۳۴۵۶۷۸۹۰', 0);
+
+    expect(wrapper.state().value).toEqual('1234567890');
+  });
+
   it('should render input as type text by default', () => {
     const wrapper = mount(<NumberFormat />);
     expect(wrapper.find('input').instance().getAttribute('type')).toEqual('text');


### PR DESCRIPTION
Sharing 'format' and 'customNumerals' props does not allow to enter symbols from the 'customNumerals' array.

Below i use your function getNumberRegex for get correct regular expression