### PR TITLE
cutTrailingZeros prop added to the component

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -114,6 +114,17 @@ class App extends React.Component {
         </div>
 
         <div className="example">
+          <h3>Remove Trailing Zeros in Decimals</h3>
+          <NumberFormat
+            isNumericString
+            thousandSeparator
+            decimalScale={5}
+            fixedDecimalScale
+            cutTrailingZeros={2}
+          />
+        </div>
+
+        <div className="example">
           <h3>Format with pattern : Format credit card in an input</h3>
           <NumberFormat format="#### #### #### ####" mask="_" />
         </div>
@@ -152,6 +163,10 @@ class App extends React.Component {
           <h3>Custom Numeral: add support for custom languages </h3>
           <NumberFormat customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} />
         </div>
+
+   
+
+
       </div>
     );
   }

--- a/src/number_format.js
+++ b/src/number_format.js
@@ -8,6 +8,7 @@ import {
   escapeRegExp,
   fixLeadingZero,
   limitToScale,
+  limitTrailingZeros,
   roundToPrecision,
   setCaretPosition,
   splitDecimal,
@@ -25,6 +26,7 @@ const defaultProps = {
   decimalSeparator: '.',
   thousandsGroupStyle: 'thousand',
   fixedDecimalScale: false,
+  cutTrailingZeros: 0,
   prefix: '',
   suffix: '',
   allowNegative: true,
@@ -478,6 +480,7 @@ class NumberFormat extends React.Component {
       suffix,
       allowNegative,
       thousandsGroupStyle,
+      cutTrailingZeros,
     } = this.props;
     const { thousandSeparator, decimalSeparator } = this.getSeparators();
 
@@ -499,6 +502,11 @@ class NumberFormat extends React.Component {
 
     //restore negation sign
     if (addNegation) beforeDecimal = '-' + beforeDecimal;
+
+    //cut trailing zeros
+    if(cutTrailingZeros){
+      afterDecimal = limitTrailingZeros(afterDecimal, cutTrailingZeros, fixedDecimalScale)
+    }
 
     numStr = beforeDecimal + ((hasDecimalSeparator && decimalSeparator) || '') + afterDecimal;
 
@@ -1069,6 +1077,7 @@ if (process.env.NODE_ENV !== 'production') {
     thousandsGroupStyle: PropTypes.oneOf(['thousand', 'lakh', 'wan']),
     decimalScale: PropTypes.number,
     fixedDecimalScale: PropTypes.bool,
+    cutTrailingZeros: PropTypes.number,
     displayType: PropTypes.oneOf(['input', 'text']),
     prefix: PropTypes.string,
     suffix: PropTypes.string,

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,6 +88,31 @@ export function limitToScale(numStr: string, scale: number, fixedDecimalScale: b
   return str;
 }
 
+/**
+ * limits decimal part such that it removes trailing zeros (if any)
+ * leaving only first *decimalsToLeaveIntact* intact 
+ */
+export function limitTrailingZeros(afterDecimal: string,  decimalsToLeaveIntact: number, fixedDecimalScale:boolean ){
+  if(afterDecimal && afterDecimal.length > 0){
+    let str = "0."+ afterDecimal;
+    let afterDecimalWithoutAnyTrailingZeros = str.replace(/^([\d,]+)$|^([\d,]+)\.0*$|^([\d,]+\.[0-9]*?)0*$/, "$1$2$3");
+    let newAfterDecimal = afterDecimalWithoutAnyTrailingZeros.includes('.')? afterDecimalWithoutAnyTrailingZeros.split('.')[1]: '0';
+    let result = ''
+
+    if(newAfterDecimal.length < decimalsToLeaveIntact){
+      const filler = fixedDecimalScale ? '0' : '';
+      for (let i = 0; i <= decimalsToLeaveIntact - 1; i++) {
+        result += newAfterDecimal[i] || filler;
+      }
+    }
+    else{
+      result = newAfterDecimal
+    }
+    return result
+  }
+  return afterDecimal;
+}
+
 function repeat(str, count) {
   return Array(count + 1).join(str);
 }


### PR DESCRIPTION
cutTrailingZeros (number) => if passed, then it will look for, and cut, **ALL trailing zeros in the decimal part of the number **, stopping at _cutTrailingZeros_ decimal point. 

So, _cutTrailingZeros_ is also used to determine the number of decimal places to leave intact when cutting trailing zeros. It's up to the developer, currently, to take care that the _cutTrailingZeros_  prop's value isn't greater than _decimalScale_ value (if used) 

In case both _decimalScale_ and _cutTrailingZero_ props are used, if _cutTrailingZero_ > _decimalScale_  and _fixedDecimal_ is used, it will display cutTrailingZero amount of decimals instead of decimalScale   amount of decimals.

examples where this prop might be useful:
 say123,456.780 and cutTrailingZeros = 2 (because we do want to keep at least 2 decimals and cut all trailing zeros after 2nd decimal place) then the result will be => 123,456.78
but if 123,456.780 and  cutTrailingZeros = 3 then the result will be => 123,456.780 .


Github issue that this PR solves: [#611](https://github.com/s-yadav/react-number-format/issues/611)

Works in all browsers
