### PR TITLE
[fix #636] ignore insertCompositionText event

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -785,37 +785,39 @@ class NumberFormat extends React.Component {
   }
 
   onChange(e: SyntheticInputEvent) {
-    const el = e.target;
-    let inputValue = el.value;
-    const { state, props } = this;
-    const { isAllowed } = props;
-    const lastValue = state.value || '';
+    if ( e.nativeEvent.inputType !== 'insertCompositionText' ){
+      const el = e.target;
+      let inputValue = el.value;
+      const { state, props } = this;
+      const { isAllowed } = props;
+      const lastValue = state.value || '';
 
-    const currentCaretPosition = getCurrentCaretPosition(el);
+      const currentCaretPosition = getCurrentCaretPosition(el);
 
-    inputValue = this.correctInputValue(currentCaretPosition, lastValue, inputValue);
+      inputValue = this.correctInputValue(currentCaretPosition, lastValue, inputValue);
 
-    let formattedValue = this.formatInput(inputValue) || '';
-    const numAsString = this.removeFormatting(formattedValue);
+      let formattedValue = this.formatInput(inputValue) || '';
+      const numAsString = this.removeFormatting(formattedValue);
 
-    const valueObj = this.getValueObject(formattedValue, numAsString);
-    const isChangeAllowed = isAllowed(valueObj);
+      const valueObj = this.getValueObject(formattedValue, numAsString);
+      const isChangeAllowed = isAllowed(valueObj);
 
-    if (!isChangeAllowed) {
-      formattedValue = lastValue;
-    }
+      if (!isChangeAllowed) {
+        formattedValue = lastValue;
+      }
 
-    this.updateValue({
-      formattedValue,
-      numAsString,
-      inputValue,
-      input: el,
-      event: e,
-      source: 'event',
-    });
+      this.updateValue({
+        formattedValue,
+        numAsString,
+        inputValue,
+        input: el,
+        event: e,
+        source: 'event',
+      });
 
-    if (isChangeAllowed) {
-      props.onChange(e);
+      if (isChangeAllowed) {
+        props.onChange(e);
+      }
     }
   }
 


### PR DESCRIPTION
#### Describe the issue/change

if ( e.nativeEvent.inputType !== 'insertCompositionText' )

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [ ] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
