### PR TITLE
fix: caret position when the first entered number is in the prefix

### DIFF
--- a/src/number_format.js
+++ b/src/number_format.js
@@ -786,11 +786,17 @@ class NumberFormat extends React.Component {
 
   onChange(e: SyntheticInputEvent) {
     const el = e.target;
-    let inputValue = el.value;
     const { state, props } = this;
     const { isAllowed } = props;
     const lastValue = state.value || '';
 
+    if (lastValue === '' && el.value && props.prefix) {
+      const prefixedValue = props.prefix + el.value;
+      el.value = prefixedValue;
+      this.setPatchedCaretPosition(el, prefixedValue.length, prefixedValue)
+    }
+
+    let inputValue = el.value;
     const currentCaretPosition = getCurrentCaretPosition(el);
 
     inputValue = this.correctInputValue(currentCaretPosition, lastValue, inputValue);

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -147,6 +147,17 @@ describe('Test keypress and caret position changes', () => {
       expect(wrapper.state().value).toEqual('123 999 845');
       expect(caretPos).toEqual(7);
     });
+
+    it('should handle entering number as first character that is also in the prefix', () => {
+      const wrapper = shallow(<NumberFormat thousandSeparator={true} prefix={'10^'} />);
+
+      simulateKeyInput(wrapper.find('input'), '1', 0, 0, setSelectionRange);
+
+      expect(wrapper.state().value).toEqual('10^1');
+      wrapper.update();
+
+      expect(caretPos).toEqual(4);
+    });
   });
 
   describe('Test delete/backspace with format pattern', () => {


### PR DESCRIPTION
#### Describe the issue/change
When `prefix` contains any number, and that number is typed as the first character, the caret position is calculated incorrectly.

In `getCaretPosition` the caret is positioned to the first occurrence of the typed character, which is in the prefix. `correctCaretPosition` then moves the caret to the first position after the prefix, but before the character we just typed in.

I tried to work it around by ensuring that the input always contains the prefix when `getCaretPosition` is called - not sure if this is the best way to fix it.

#### Add CodeSandbox link to illustrate the issue (If applicable)
https://codepen.io/attila_n/pen/mdxdowd

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [X] Chrome
- [ ] Chrome (Android)
- [X] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
