### PR TITLE
Added missing build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build-doc": "docusaurus build documentation/v5",
     "publish-doc": "node publish_doc.js",
     "format": "prettier --write ./src ./test ./example",
-    "build": "cross-env yarn build-dist && yarn test-build && yarn test-ts && yarn format && yarn build-doc && yarn publish-doc",
+    "build": "cross-env yarn build-dist && yarn build-types && yarn test-build && yarn test-ts && yarn format && yarn build-doc && yarn publish-doc",
     "build-dist": "cross-env NODE_ENV=production rollup -c rollup.config.js",
     "build-types": "tsc -p tsconfig.build.json",
     "test": "cross-env NODE_ENV=test karma start && yarn test-ts",


### PR DESCRIPTION
The build script was missing 'yarn build-types', as a result the npm package was missing type declaration.

#### Describe the issue/change

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [ ] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
