### PR TITLE
Fix card expiry demo with usePatternFormat

### DIFF
--- a/documentation/v5/docs/customization.md
+++ b/documentation/v5/docs/customization.md
@@ -145,7 +145,7 @@ function CardExpiry(props) {
     return format(`${month}${year}`);
   };
 
-  return <NumberFormatBase format={_format} {...rest} />;
+  return <NumberFormatBase format={_format} {...props} />;
 }
 ```
 

--- a/documentation/v5/docs/customization.md
+++ b/documentation/v5/docs/customization.md
@@ -145,7 +145,7 @@ function CardExpiry(props) {
     return format(`${month}${year}`);
   };
 
-  return <NumberFormatBase format={_format} {...rest} {...props} />;
+  return <NumberFormatBase {...props} format={_format} {...rest} />;
 }
 ```
 

--- a/documentation/v5/docs/customization.md
+++ b/documentation/v5/docs/customization.md
@@ -145,7 +145,7 @@ function CardExpiry(props) {
     return format(`${month}${year}`);
   };
 
-  return <NumberFormatBase format={_format} {...props} />;
+  return <NumberFormatBase format={_format} {...rest} {...props} />;
 }
 ```
 

--- a/documentation/v5/docs/customization.md
+++ b/documentation/v5/docs/customization.md
@@ -153,12 +153,12 @@ function CardExpiry(props) {
   <summary>
   Demo
   </summary>
-  <iframe src="https://codesandbox.io/embed/card-expiry-field-pattern-format-3yzksf?fontsize=14&hidenavigation=1&theme=dark&view=preview"
-     title="Card Expiry Field (Pattern Format)"
+  <iframe src="https://codesandbox.io/embed/card-expiry-field-with-usepatternformat-2wd7ej?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+     title="Card Expiry Field with usePatternFormat"
      className="csb"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-   ></iframe> 
+   ></iframe>
 </details>
 
 Another example for NumericFormat could be support for custom numerals.


### PR DESCRIPTION
The card Expiry demo with the `usePatternFormat` hook does not trigger the `onValueChange` since the `NumberFormatBase` isn't getting it via the `...rest` variable. 
