### PR TITLE
Adding format on type feature prop

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -154,6 +154,26 @@ class App extends React.Component {
           <h3>Custom Numeral: add support for custom languages </h3>
           <NumericFormat customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} />
         </div>
+
+        <div className="example">
+          <h3>Format on type</h3>
+          <PatternFormat format="###.###.###-##" formatOnType />
+        </div>
+
+        <div className="example">
+          <h3>Format phone number on type</h3>
+          <PatternFormat format="+1 (###) ###-####" formatOnType />
+        </div>
+
+        <div className="example">
+          <h3>Format postal code on type</h3>
+          <PatternFormat format="##.###-###" formatOnType />
+        </div>
+
+        <div className="example">
+          <h3>Format date on type</h3>
+          <PatternFormat format="##/##/####" formatOnType />
+        </div>
       </div>
     );
   }

--- a/src/pattern_format.tsx
+++ b/src/pattern_format.tsx
@@ -9,20 +9,44 @@ import {
 } from './utils';
 import NumberFormatBase from './number_format_base';
 
+function _getFormattedNumberArray(format: string, patternChar: string, numStr: string, formatOnType: boolean) {
+  const formatArray = format.split('');
+  if (!formatOnType) {
+    return formatArray;
+  }
+  let hashCount = 0;
+  // find last pattern index
+  const replacePatternIdx = formatArray.findIndex((char) => {
+    if (char === patternChar) {
+      hashCount += 1;
+    }
+    return hashCount === numStr.length
+  })
+
+  // filter format array until numStr length
+  return formatArray.filter((_, index) => {
+    return replacePatternIdx >= 0 
+      ? index <= replacePatternIdx
+      : true
+  });
+}
+
 export function format<BaseType = InputAttributes>(
   numStr: string,
   props: PatternFormatProps<BaseType>,
 ) {
   const format = props.format as string;
-  const { allowEmptyFormatting, mask, patternChar = '#' } = props;
+  const { allowEmptyFormatting, mask, patternChar = '#', formatOnType } = props;
 
   if (numStr === '' && !allowEmptyFormatting) return '';
 
-  let hashCount = 0;
-  const formattedNumberAry = format.split('');
+  const formattedNumberAry = _getFormattedNumberArray(format, patternChar, numStr, formatOnType);
+  
+  let hashCount = 0
+
   for (let i = 0, ln = format.length; i < ln; i++) {
     if (format[i] === patternChar) {
-      formattedNumberAry[i] = numStr[hashCount] || getMaskAtIndex(mask, hashCount);
+      formattedNumberAry[i] = numStr[hashCount] || getMaskAtIndex(mask, hashCount, formatOnType);
       hashCount += 1;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export type PatternFormatProps<BaseType = InputAttributes> = NumberFormatProps<
     mask?: string | string[];
     allowEmptyFormatting?: boolean;
     patternChar?: string;
+    formatOnType?: boolean;
   },
   BaseType
 >;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -294,7 +294,7 @@ export function getDefaultChangeMeta(value: string) {
   };
 }
 
-export function getMaskAtIndex(mask: string | string[] = ' ', index: number) {
+export function getMaskAtIndex(mask: string | string[] = ' ', index: number, formatOnType = false) {
   if (typeof mask === 'string') {
     return mask;
   }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -295,6 +295,9 @@ export function getDefaultChangeMeta(value: string) {
 }
 
 export function getMaskAtIndex(mask: string | string[] = ' ', index: number, formatOnType = false) {
+  if (formatOnType) {
+    return '';
+  }
   if (typeof mask === 'string') {
     return mask;
   }


### PR DESCRIPTION
#### Describe the issue/change
Hi! This is a suggestion for a new feature to show mask only when typing.

#### Describe the changes proposed/implemented in this PR
This PR propose a new prop called formatOnType, this new prop only show the mask when typing, eliminating white spaces and improving screen readers.

#### Example usage (If applicable)
````
<PatternFormat format="+1 (###) ###-####" formatOnType />
````
#### Screenshot (If applicable)
This video below is how is the library today, the mask already show on input when start typing.
https://user-images.githubusercontent.com/21287627/192879722-9c9728ab-d60e-404f-9e17-c3ce84124f35.mov


This video below is the suggestion. Realize that mask only show when digit comes to mask.
https://user-images.githubusercontent.com/21287627/192880076-3814b96f-b716-46ab-b39e-e58b54ef301f.mov

#### Please check which browsers were used for testing
- [x] Chrome
- [x] Chrome (Android)
- [x] Safari (OSX)
- [x] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
