### PR TITLE
Pass type parameter to SyntheticEvent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export enum SourceType {
 }
 
 export interface SourceInfo {
-  event?: SyntheticEvent;
+  event?: SyntheticEvent<HTMLInputElement>;
   source: SourceType;
 }
 


### PR DESCRIPTION
#### Describe the issue/change
Currently the type of `event` that `SourceInfo` has is `SyntheticEvent` with no type argument. In the implementation, I believe that it is the `input` element that fires the event, so `SyntheticEvent<HTMLInputElement>` should be more appropriate here. This change will improve integration with other libraries such as MUI in terms of TypeScript types.

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR
https://github.com/s-yadav/react-number-format/blob/master/src/types.ts#L23
befor: `SyntheticEvent`
after: `SyntheticEvent<HTMLInputElement>`

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
