### PR TITLE
Mark module as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/react-number-format.cjs.js",
   "module": "dist/react-number-format.es.js",
   "types": "types/index.d.ts",
+  "sideEffects": false,
   "author": "Sudhanshu Yadav",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Describe the issue/change
This should enable webpack and other bundlers to only import used functions and components.