### PR TITLE
Fix decimalSeparator with a suffix containing more than one character

### DIFF
--- a/src/numeric_format.tsx
+++ b/src/numeric_format.tsx
@@ -473,6 +473,11 @@ export function useNumericFormat<BaseType = InputAttributes>(
 
   const isValidInputCharacter = (inputChar: string) => {
     if (inputChar === decimalSeparator) return true;
+
+    if (allowedDecimalSeparators.includes(inputChar)) {
+      return true;
+    }
+
     return charIsNumber(inputChar);
   };
 

--- a/src/numeric_format.tsx
+++ b/src/numeric_format.tsx
@@ -474,7 +474,7 @@ export function useNumericFormat<BaseType = InputAttributes>(
   const isValidInputCharacter = (inputChar: string) => {
     if (inputChar === decimalSeparator) return true;
 
-    if (allowedDecimalSeparators.includes(inputChar)) {
+    if (allowedDecimalSeparators?.includes(inputChar)) {
       return true;
     }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -331,7 +331,13 @@ export function getCaretPosition(
   for (let i = 0; i < curValLn; i++) {
     indexMap[i] = -1;
     for (let j = 0, jLn = formattedValueLn; j < jLn; j++) {
-      if (curValue[i] === newFormattedValue[j] && addedIndexMap[j] !== true) {
+      const isAllowedDecimalSeparator =
+        isValidInputCharacter(curValue[i]) && isValidInputCharacter(newFormattedValue[j]);
+
+      if (
+        (curValue[i] === newFormattedValue[j] || isAllowedDecimalSeparator) &&
+        addedIndexMap[j] !== true
+      ) {
         indexMap[i] = j;
         addedIndexMap[j] = true;
         break;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -333,10 +333,9 @@ export function getCaretPosition(
     for (let j = 0, jLn = formattedValueLn; j < jLn; j++) {
       const isAllowedDecimalSeparator =
         isValidInputCharacter(curValue[i]) && isValidInputCharacter(newFormattedValue[j]);
-
       if (
-        (curValue[i] === newFormattedValue[j] || isAllowedDecimalSeparator) &&
-        addedIndexMap[j] !== true
+        (curValue[i] === newFormattedValue[j] && addedIndexMap[j] !== true) ||
+        (isAllowedDecimalSeparator && i === 0 && j === 0)
       ) {
         indexMap[i] = j;
         addedIndexMap[j] = true;


### PR DESCRIPTION
#### Describe the issue/change

This PR fixes issue described in [#725](https://github.com/s-yadav/react-number-format/issues/725)

#### Describe the changes proposed/implemented in this PR

As [romanopassalacqua](https://github.com/romanopassalacqua) suggested, we now check if char is in allowedDecimalSeparators in getCaretPosition. Before we only checked if chars were the same resulting that indexMap was not affected. This caused problem described in [#725](https://github.com/s-yadav/react-number-format/issues/725) when using some of the allowedDecimalSeparators which is not (default) decimalSeparator.

#### Link Github issue if this PR solved an existing issue

 [#725](https://github.com/s-yadav/react-number-format/issues/725)

#### Example usage (If applicable)


```
        <div className="example">
          <h3>A suffix containing more than one character</h3>
          <NumericFormat
            suffix={' €'}
            allowedDecimalSeparators={['.', ',']}
          />
        </div>

        <div className="example">
          <h3>A long suffix</h3>
          <NumericFormat
            suffix={'longsuffix'}
            allowedDecimalSeparators={['.', ',']}
          />
        </div>

        <div className="example">
          <h3>A superlong suffix</h3>
          <NumericFormat
            suffix={'superlongsuffix with spaces'}
            allowedDecimalSeparators={['.', ',']}
          />
        </div>

```
#### Video

https://user-images.githubusercontent.com/19435681/223791397-3c7efa76-29e7-4f96-846b-933a2813d542.mp4

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [x] Firefox
- [ ] Firefox (Android)
