### PR TITLE
Add support for minDecimalScale

### DIFF
--- a/documentation/v5/docs/numeric_format.md
+++ b/documentation/v5/docs/numeric_format.md
@@ -130,6 +130,31 @@ import { NumericFormat } from 'react-number-format';
    ></iframe>
 </details>
 
+### minDecimalScale `number`
+
+**default**: `undefined`
+
+If defined, it enforces a minimum number of digits after the decimal point.
+
+```js
+import { NumericFormat } from 'react-number-format';
+
+<NumericFormat value={12323.3334} minDecimalScale={3} />;
+```
+
+<details>
+  <summary>
+  Demo
+  </summary>
+
+<iframe src="https://codesandbox.io/embed/decimalscale-demo-uc92li?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+     className='csb'
+     title="decimalScale-demo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+</details>
+
 ### decimalSeparator `string`
 
 **default**: '.'

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export type NumericFormatProps<BaseType = InputAttributes> = NumberFormatProps<
     allowedDecimalSeparators?: Array<string>;
     thousandsGroupStyle?: 'thousand' | 'lakh' | 'wan' | 'none';
     decimalScale?: number;
+    minDecimalScale?: number;
     fixedDecimalScale?: boolean;
     allowNegative?: boolean;
     allowLeadingZeros?: boolean;

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -215,6 +215,22 @@ describe('Test NumberFormat as input with numeric format options', () => {
     expect(getInputValue(wrapper)).toEqual('4111.11');
   });
 
+  it('should enforce a minimum decimal scale if specified', () => {
+    const wrapper = mount(<NumericFormat decimalScale={8} minDecimalScale={2} value={24} />);
+    expect(getInputValue(wrapper)).toEqual('24.00');
+
+    const input = wrapper.find('input');
+    input.simulate('change', getCustomEvent('24.1234'));
+    expect(getInputValue(wrapper)).toEqual('24.1234');
+
+    input.simulate('change', getCustomEvent('24.1234567890'));
+    expect(getInputValue(wrapper)).toEqual('24.12345678');
+
+    // Rounding logic
+    wrapper.setProps({ value: 24.123456789 });
+    expect(getInputValue(wrapper)).toEqual('24.12345679');
+  });
+
   it('should not add zeros to fixedDecimalScale is not set', () => {
     const wrapper = mount(<NumericFormat decimalScale={4} value={24.45} />);
     expect(getInputValue(wrapper)).toEqual('24.45');


### PR DESCRIPTION
#### Describe the issue/change

- In many currency-related use cases, a minimal decimal precision of 2 digits is common. This way, large numbers get displayed with two padded zeroes (i.e. $1,000,000.00) while small numbers support added precision of up-to n digits ($0.89765412 if n=8)

- This functionality is not currently possible with this library due to fixedDecimalScale enforcing EXACTLY n digits of precision, while decimalScale provides only a MAXIMUM number of digits when used on its own

- In a future release (since it would be a breaking change) we can probably remove `fixedDecimalScale` and use only `minDecimalScale` and `decimalScale` to clamp the bounds of precision and satisfy every use case

#### Example usage (If applicable)
```
<NumberFormat minDecimalScale={2} decimalScale={8} value={24}/> 
```

#### Please check which browsers were used for testing
- [X] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
