### PR TITLE
Optimize render

### DIFF
--- a/documentation/v5/docs/numeric_format.md
+++ b/documentation/v5/docs/numeric_format.md
@@ -260,3 +260,61 @@ import { NumericFormat } from 'react-number-format';
 - [See Common Props](/docs/props)
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**
+
+## Other exports
+
+With v5.0 we expose some more utils/hooks which can be used for customization or other utilities
+
+### numericFormatter `(numString: string, props: NumericFormatProps) => string`
+
+In some places we need to just format the number before we pass it down as value, or in general just to render it. In such cases `numericFormatter` can be used directly.
+
+**Parameters**
+
+1st. `numString`(non formatted number string)
+
+2nd. `props` (the format props applicable on numeric format)
+
+**Return**
+`formattedString` returns the formatted number.
+
+### removeNumericFormat `(inputValue: string, changeMeta: ChangeMeta, props: NumericFormatProps) => string`
+
+Most of the time you might not need this, but in some customization case you might wan't to write a patched version on top of removeNumericFormat.
+
+However for customization case its recommended to use `useNumericFormat` and patch the methods it returns, as lot of other handling is done in the hook.
+
+**Parameters**
+
+1st. `inputValue`: the value after user has typed, this will be formatted value with the additional character typed by user.
+
+2nd. `changeMeta`: This is the change information rnf sends internally, its basically the change information from the last formatted value and the current typed input value.
+
+The type is following
+
+```js
+{
+  from: {start: number, end: number},
+  to: {start: number, end: number},
+  lastValue: string
+}
+```
+
+3rd. `props`: all the numeric format props
+
+**Return**
+`numString` returns the number in string format.
+
+### getNumericCaretBoundary `(formattedValue: string, props: NumericFormatProps) => Array<boolean>`
+
+This method returns information about what all position in formatted value where caret can be places, it returns n+1 length array of booleans(where n is the length of formattedValue).
+
+Most of time you don't need this, but in case if you very specific usecase you can patch the function to handle your case.
+
+See more details on [Concept](https://s-yadav.github.io/react-number-format/docs/customization/#concept)
+
+### useNumericFormat: `(props: NumericFormatProps) => NumberFormatBaseProps`
+
+The whole numeric format logic is inside useNumericFormat hook, this returns all the required props which can be passed to `NumberFormatBase`. For customization you can use to patch methods returned by `useNumericFormat` and pass to `NumberFormatBase`.
+
+See more details in [Customization](https://s-yadav.github.io/react-number-format/docs/customization/)

--- a/documentation/v5/docs/pattern_format.md
+++ b/documentation/v5/docs/pattern_format.md
@@ -106,3 +106,61 @@ Demo
 - [See Common Props](/docs/props)
 
 **Other than this it accepts all the props which can be given to a input or span based on displayType you selected.**
+
+## Other exports
+
+With v5.0 we expose some more utils/hooks which can be used for customization or other utilities
+
+### patternFormatter `(numString: string, props: PatternFormatProps) => string`
+
+In some places we need to just format the number before we pass it down as value, or in general just to render it. In such cases `patternFormatter` can be used directly.
+
+**Parameters**
+
+1st. `numString`(non formatted number string)
+
+2nd. `props` (the format props applicable on numeric format)
+
+**Return**
+`formattedString` returns the formatted number.
+
+### removePatternFormat `(inputValue: string, changeMeta: ChangeMeta, props: PatternFormatProps) => string`
+
+Most of the time you might not need this, but in some customization case you might wan't to write a patched version on top of removePatternFormat.
+
+However for customization case its recommended to use `usePatternFormat` and patch the methods it returns, as lot of other handling is done in the hook.
+
+**Parameters**
+
+1st. `inputValue`: the value after user has typed, this will be formatted value with the additional character typed by user.
+
+2nd. `changeMeta`: This is the change information rnf sends internally, its basically the change information from the last formatted value and the current typed input value.
+
+The type is following
+
+```js
+{
+  from: {start: number, end: number},
+  to: {start: number, end: number},
+  lastValue: string
+}
+```
+
+3rd. `props`: all the numeric format props
+
+**Return**
+`numString` returns the number in string format.
+
+### getPatternCaretBoundary `(formattedValue: string, props: PatternFormatProps) => Array<boolean>`
+
+This method returns information about what all position in formatted value where caret can be places, it returns n+1 length array of booleans(where n is the length of formattedValue).
+
+Most of time you don't need this, but in case if you very specific usecase you can patch the function to handle your case.
+
+See more details on [Concept](https://s-yadav.github.io/react-number-format/docs/customization/#concept)
+
+### usePatternFormat: `(props: PatternFormatProps) => NumberFormatBaseProps`
+
+The whole numeric format logic is inside usePatternFormat hook, this returns all the required props which can be passed to `NumberFormatBase`. For customization you can use to patch methods returned by `usePatternFormat` and pass to `NumberFormatBase`.
+
+See more details in [Customization](https://s-yadav.github.io/react-number-format/docs/customization/)

--- a/documentation/v5/docs/props.md
+++ b/documentation/v5/docs/props.md
@@ -160,18 +160,14 @@ const MAX_LIMIT = 1000;
 
 **default**: false
 
-If value is passed as string representation of numbers (unformatted) then this should be passed as `true`.
+If value is passed as string representation of numbers (unformatted) and number is used in any format props like in prefix or suffix in numeric format and format prop in pattern format then this should be passed as `true`.
+
+**Note**: Prior to 5.2.0 its was always required to be passed as true when value is passed as string representation of numbers (unformatted).
 
 ```js
-import { NumericFormat } from 'react-number-format';
+import { PatternFormat } from 'react-number-format';
 
-<NumericFormat
-  type="text"
-  value="123456789"
-  valueIsNumericString={true}
-  decimalSeparator=","
-  displayType="input"
-/>;
+<PatternFormat format="+1 (###) ###-####" value="123456789" valueIsNumericString={true} />;
 ```
 
 <details>
@@ -194,7 +190,7 @@ import { NumericFormat } from 'react-number-format';
 This handler provides access to any values changes in the input field and is triggered only when a prop changes or the user input changes. It provides two arguments namely the [valueObject](quirks#values-object) as the first and the [sourceInfo](quirks#sourceInfo) as the second. The [valueObject](quirks#values-object) parameter contains the `formattedValue`, `value` and the `floatValue` of the given input field. The [sourceInfo](quirks#sourceInfo) contains the `event` Object and a `source` key which indicates whether the triggered change is due to an event or a prop change. This is particularly useful in identify whether the change is user driven or is an uncontrolled change due to any prop value being updated.
 
 :::info
-If you are using `values.value` which is non formatted value as numeric string. Make sure to pass valueIsNumericString to be true.
+If you are using `values.value` which is non formatted value as numeric string. Make sure to pass valueIsNumericString to be true if any of the format prop as number on it. See [valueIsNumericString](#valueisnumericstring-boolean) for more details.
 :::
 
 ```js

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -7,43 +7,6 @@ import NumberFormatBase from '../../src/number_format_base';
 import TextField from 'material-ui/TextField';
 import { cardExpiry } from '../../custom_formatters/card_expiry';
 
-export default function Test() {
-  const localInputRef = React.useRef();
-  // Simulates both eager typing and waiting for an arbitratry amount of time
-  React.useEffect(() => {
-    // If we call select too early, the `NumericFormat`'s
-    // `setPatchedCaretPosition` function will reset the selection. To avoid
-    // this, we need to wait for 3 task cycles (empirically determined)
-    // before calling it.
-    //
-    // cf. https://github.com/s-yadav/react-number-format/blob/3443f1adf3a904c19a9fca1183cf3af08a0bf714/src/number_format_base.tsx#L127-L133
-    console.log('inside Test', localInputRef.current);
-    localInputRef.current?.select();
-    console.log(
-      '--------',
-      localInputRef.current?.selectionStart,
-      localInputRef.current?.selectionEnd,
-    );
-  }, []);
-
-  return (
-    <div>
-      <label>
-        <div>NumericFormat</div>
-        <NumericFormat
-          value="12345"
-          getInputRef={(elm) => (localInputRef.current = elm)}
-          suffix="$"
-        />
-      </label>
-      <label>
-        <div>Native input</div>
-        <input value="12345" />
-      </label>
-    </div>
-  );
-}
-
 class App extends React.Component {
   constructor() {
     super();
@@ -57,8 +20,7 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <Test />
-        {/* <div className="example">
+        <div className="example">
           <h3>Prefix and thousand separator : Format currency as text</h3>
           <NumericFormat value={2456981} displayType="text" thousandSeparator={true} prefix="$" />
         </div>
@@ -191,7 +153,7 @@ class App extends React.Component {
         <div className="example">
           <h3>Custom Numeral: add support for custom languages </h3>
           <NumericFormat customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} />
-        </div> */}
+        </div>
       </div>
     );
   }

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -7,6 +7,43 @@ import NumberFormatBase from '../../src/number_format_base';
 import TextField from 'material-ui/TextField';
 import { cardExpiry } from '../../custom_formatters/card_expiry';
 
+export default function Test() {
+  const localInputRef = React.useRef();
+  // Simulates both eager typing and waiting for an arbitratry amount of time
+  React.useEffect(() => {
+    // If we call select too early, the `NumericFormat`'s
+    // `setPatchedCaretPosition` function will reset the selection. To avoid
+    // this, we need to wait for 3 task cycles (empirically determined)
+    // before calling it.
+    //
+    // cf. https://github.com/s-yadav/react-number-format/blob/3443f1adf3a904c19a9fca1183cf3af08a0bf714/src/number_format_base.tsx#L127-L133
+    console.log('inside Test', localInputRef.current);
+    localInputRef.current?.select();
+    console.log(
+      '--------',
+      localInputRef.current?.selectionStart,
+      localInputRef.current?.selectionEnd,
+    );
+  }, []);
+
+  return (
+    <div>
+      <label>
+        <div>NumericFormat</div>
+        <NumericFormat
+          value="12345"
+          getInputRef={(elm) => (localInputRef.current = elm)}
+          suffix="$"
+        />
+      </label>
+      <label>
+        <div>Native input</div>
+        <input value="12345" />
+      </label>
+    </div>
+  );
+}
+
 class App extends React.Component {
   constructor() {
     super();
@@ -20,7 +57,8 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <div className="example">
+        <Test />
+        {/* <div className="example">
           <h3>Prefix and thousand separator : Format currency as text</h3>
           <NumericFormat value={2456981} displayType="text" thousandSeparator={true} prefix="$" />
         </div>
@@ -153,7 +191,7 @@ class App extends React.Component {
         <div className="example">
           <h3>Custom Numeral: add support for custom languages </h3>
           <NumericFormat customNumerals={['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']} />
-        </div>
+        </div> */}
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-number-format",
   "description": "React component to format number in an input or as a text.",
-  "version": "5.1.4",
+  "version": "5.2.0",
   "main": "dist/react-number-format.cjs.js",
   "module": "dist/react-number-format.es.js",
   "types": "types/index.d.ts",

--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -224,17 +224,25 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
   }, [formattedValue, numAsString]);
 
   // also if formatted value is changed from the props, we need to update the caret position
+  // keep the last caret position if element is focused
+  const currentCaretPosition = focusedElm.current
+    ? geInputCaretPosition(focusedElm.current)
+    : undefined;
+
   useLayoutEffect(() => {
     const input = focusedElm.current;
     if (formattedValue !== lastUpdatedValue.current.formattedValue && input) {
-      updateValueAndCaretPosition({
-        formattedValue: formattedValue,
-        numAsString: numAsString,
-        input,
-        setCaretPosition: true,
-        source: SourceType.props,
-        event: undefined,
-      });
+      const caretPos = getNewCaretPosition(
+        lastUpdatedValue.current.formattedValue,
+        formattedValue,
+        currentCaretPosition,
+      );
+      /**
+       * set the value imperatively, as we set the caret position as well imperatively.
+       * This is to keep value and caret position in sync
+       */
+      input.value = formattedValue;
+      setPatchedCaretPosition(input, caretPos, formattedValue);
     }
   }, [formattedValue]);
 

--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -326,6 +326,10 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     if (key === 'ArrowLeft' || key === 'ArrowRight') {
       const direction = key === 'ArrowLeft' ? 'left' : 'right';
       newCaretPosition = correctCaretPosition(value, expectedCaretPosition, direction);
+      // arrow left or right only moves the caret, so no need to handle the event, if we are handling it manually
+      if (newCaretPosition !== expectedCaretPosition) {
+        e.preventDefault();
+      }
     } else if (key === 'Delete' && !isValidInputCharacter(value[expectedCaretPosition])) {
       // in case of delete go to closest caret boundary on the right side
       newCaretPosition = correctCaretPosition(value, expectedCaretPosition, 'right');

--- a/src/numeric_format.tsx
+++ b/src/numeric_format.tsx
@@ -366,9 +366,9 @@ export function useNumericFormat<BaseType = InputAttributes>(
   let _valueIsNumericString = valueIsNumericString ?? isNumericString(_value, prefix, suffix);
 
   if (!isNil(value)) {
-    _valueIsNumericString = valueIsNumericString ?? typeof value === 'number';
+    _valueIsNumericString = valueIsNumericString || typeof value === 'number';
   } else if (!isNil(defaultValue)) {
-    _valueIsNumericString = valueIsNumericString ?? typeof defaultValue === 'number';
+    _valueIsNumericString = valueIsNumericString || typeof defaultValue === 'number';
   }
 
   const roundIncomingValueToPrecision = (value: string | number | null | undefined) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,8 +62,8 @@ type NumberFormatBase = {
   displayType?: 'input' | 'text';
   inputMode?: InputAttributes['inputMode'];
   renderText?: (formattedValue: string, otherProps: Partial<NumberFormatBase>) => React.ReactNode;
-  format: FormatInputValueFunction;
-  removeFormatting: RemoveFormattingFunction;
+  format?: FormatInputValueFunction;
+  removeFormatting?: RemoveFormattingFunction;
   getInputRef?: ((el: HTMLInputElement) => void) | React.Ref<any>;
   value?: number | string | null;
   defaultValue?: number | string | null;
@@ -75,7 +75,7 @@ type NumberFormatBase = {
   onChange?: InputAttributes['onChange'];
   onFocus?: InputAttributes['onFocus'];
   onBlur?: InputAttributes['onBlur'];
-  getCaretBoundary: (formattedValue: string) => boolean[];
+  getCaretBoundary?: (formattedValue: string) => boolean[];
   isValidInputCharacter?: (character: string) => boolean;
 };
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { NumberFormatBaseProps, FormatInputValueFunction, OnValueChange } from './types';
 
 // basic noop function
@@ -17,6 +17,10 @@ export function isNil(val: any): val is null | undefined {
 
 export function isNanValue(val: string | number) {
   return typeof val === 'number' && isNaN(val);
+}
+
+export function isNotValidValue(val: string | number | null | undefined) {
+  return isNil(val) || isNanValue(val) || (typeof val === 'number' && !isFinite(val));
 }
 
 export function escapeRegExp(str: string) {
@@ -426,7 +430,7 @@ export function useInternalValues(
   const getValues = usePersistentCallback(
     (value: string | number | null | undefined, valueIsNumericString: boolean) => {
       let formattedValue, numAsString;
-      if (isNil(value) || isNanValue(value)) {
+      if (isNotValidValue(value)) {
         numAsString = '';
         formattedValue = '';
       } else if (typeof value === 'number' || valueIsNumericString) {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -314,6 +314,15 @@ export function getCaretPosition(
   boundary: boolean[],
   isValidInputCharacter: (char: string) => boolean,
 ) {
+  const changeRange = findChangeRange(curValue, newFormattedValue);
+  const { from, to } = changeRange;
+
+  // if only last typed character is changed in the
+  if (from.end - from.start === 1 && from.end === to.end && to.end === curCaretPos) {
+    // don't do anything
+    return curCaretPos;
+  }
+
   /**
    * if something got inserted on empty value, add the formatted character before the current value,
    * This is to avoid the case where typed character is present on format characters

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -463,15 +463,29 @@ describe('NumberFormat as input', () => {
     expect(getInputValue(wrapper)).toEqual('1.2');
   });
 
-  it('should call onValueChange in change caused by prop change', () => {
+  it('should call onValueChange in change caused by prop change', async (done) => {
     const spy = jasmine.createSpy();
-    const wrapper = mount(<NumericFormat value="1234" onValueChange={spy} />);
-    wrapper.setProps({ thousandSeparator: true });
+    const { rerender } = await render(
+      <NumericFormat value="1234" valueIsNumericString onValueChange={spy} />,
+    );
+    await rerender(
+      <NumericFormat
+        value="1234"
+        valueIsNumericString
+        thousandSeparator={true}
+        onValueChange={spy}
+      />,
+    );
+
+    await wait(100);
+
     expect(spy.calls.argsFor(0)[0]).toEqual({
       formattedValue: '1,234',
       value: '1234',
       floatValue: 1234,
     });
+
+    done();
   });
 
   it('should call onValueChange with the right source information', () => {

--- a/test/library/input.spec.js
+++ b/test/library/input.spec.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { renderHook } from '@testing-library/react-hooks/dom';
 
 import TextField from 'material-ui/TextField';
@@ -525,6 +525,22 @@ describe('NumberFormat as input', () => {
       expect(spy).toHaveBeenCalled();
       done();
     }, 0);
+  });
+
+  it('should not reset the selection when manually focused on mount', async () => {
+    function Test() {
+      const localInputRef = useRef();
+      useEffect(() => {
+        // eslint-disable-next-line no-unused-expressions
+        localInputRef.current?.select();
+      }, []);
+
+      return <NumericFormat getInputRef={(elm) => (localInputRef.current = elm)} value="12345" />;
+    }
+
+    const { input } = await render(<Test />);
+    expect(input.selectionStart).toEqual(0);
+    expect(input.selectionEnd).toEqual(5);
   });
 
   it('should not call onFocus prop when focused then blurred in the same event loop', (done) => {

--- a/test/library/input_numeric_format.spec.js
+++ b/test/library/input_numeric_format.spec.js
@@ -687,6 +687,13 @@ describe('Test NumberFormat as input with numeric format options', () => {
     expect(wrapper.find('input').prop('value')).toEqual('0.00000001');
   });
 
+  it('should handle formatting correctly when valueIsNumericString is set to false and float value is provided, #741', async () => {
+    const { input } = await render(
+      <NumericFormat value={12345} valueIsNumericString={false} thousandSeparator={true} />,
+    );
+    expect(input.value).toEqual('12,345');
+  });
+
   describe('should allow typing number if prefix or suffix is just an number #691', () => {
     it('when prefix is number', async () => {
       const { input } = await render(<NumericFormat prefix="1" />);

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -34,7 +34,7 @@ describe('Test keypress and caret position changes', () => {
     cleanup();
   });
 
-  it('should maintain caret position if suffix/prefix is updated while typing #249', () => {
+  it('should maintain caret position if suffix/prefix is updated while typing #249', async () => {
     class TestComp extends React.Component {
       constructor() {
         super();
@@ -58,15 +58,15 @@ describe('Test keypress and caret position changes', () => {
       }
     }
 
-    const wrapper = mount(<TestComp />);
-    simulateFocusEvent(wrapper.find('input'), 0, 0, setSelectionRange);
-    simulateKeyInput(wrapper.find('input'), '4', 2, 2, setSelectionRange);
-    expect(ReactDOM.findDOMNode(wrapper.instance()).value).toEqual('$$1423');
-    expect(caretPos).toEqual(4);
+    const { input } = await render(<TestComp />);
+    simulateNativeKeyInput(input, '4', 2, 2);
+    expect(input.value).toEqual('$$1423');
+    expect(input.selectionStart).toEqual(4);
 
-    simulateKeyInput(wrapper.find('input'), 'Backspace', 4, 4, setSelectionRange);
-    expect(ReactDOM.findDOMNode(wrapper.instance()).value).toEqual('$123');
-    expect(caretPos).toEqual(2);
+    simulateNativeKeyInput(input, '{backspace}', 4, 4);
+
+    expect(input.value).toEqual('$123');
+    expect(input.selectionStart).toEqual(2);
   });
 
   it('should maintain caret position when isAllowed returns false', async () => {

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -512,7 +512,7 @@ describe('Test keypress and caret position changes', () => {
       expect(onFocus).toHaveBeenCalledTimes(0);
     });
 
-    it('should correct wrong caret positon on focus when allowEmptyFormatting is set', () => {
+    it('should correct wrong caret position on focus when allowEmptyFormatting is set', () => {
       jasmine.clock().install();
       const wrapper = mount(
         <PatternFormat

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -130,6 +130,21 @@ describe('Test keypress and caret position changes', () => {
     expect(input.selectionStart).toEqual(2);
   });
 
+  it('should handle caret position correctly when suffix starts with space and allowed decimal separator is pressed. #725', async () => {
+    const { input } = await render(
+      <NumericFormat
+        value={0}
+        decimalSeparator=","
+        allowedDecimalSeparators={['%', '.']}
+        decimalScale={2}
+        suffix=" €"
+      />,
+    );
+
+    simulateNativeKeyInput(input, '.', 1, 1);
+    expect(input.selectionStart).toEqual(2);
+  });
+
   describe('Test character insertion', () => {
     it('should add any number properly when input is empty without format prop passed', async () => {
       const { input } = await render(<NumericFormat thousandSeparator={true} prefix={'$'} />);

--- a/test/library/keypress_and_caret.spec.js
+++ b/test/library/keypress_and_caret.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NumericFormat from '../../src/numeric_format';
 import PatternFormat from '../../src/pattern_format';
 import NumberFormatBase from '../../src/number_format_base';
@@ -104,6 +104,32 @@ describe('Test keypress and caret position changes', () => {
 
     simulateNativeKeyInput(input, '.', 2, 2);
     expect(input.selectionStart).toEqual(3);
+  });
+
+  it('should not break the cursor position when format prop is updated', async () => {
+    const Test = () => {
+      const [val, setValue] = useState();
+      return (
+        <NumericFormat
+          thousandSeparator=" "
+          decimalScale={2}
+          placeholder="0,00"
+          fixedDecimalScale
+          thousandsGroupStyle="thousand"
+          decimalSeparator=","
+          value={val}
+          onValueChange={(v) => {
+            setValue(v.floatValue);
+          }}
+          prefix={val > 0 ? '+' : undefined}
+        />
+      );
+    };
+
+    const { input } = await render(<Test />);
+    simulateNativeKeyInput(input, '1', 0, 0);
+    expect(input.value).toEqual('+1,00');
+    expect(input.selectionStart).toEqual(2);
   });
 
   describe('Test character insertion', () => {

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -131,6 +131,16 @@ export function simulateNativeKeyInput(input, key, selectionStart = 0, selection
   userEvent.type(input, key);
 }
 
+export function simulatePaste(input, test, selectionStart = 0, selectionEnd = 0) {
+  input.setSelectionRange(selectionStart, selectionEnd);
+  userEvent.paste(input, test);
+}
+
+export function simulateNativeMouseUpEvent(input, selectionStart) {
+  input.setSelectionRange(selectionStart, selectionStart);
+  userEvent.click(input);
+}
+
 export function simulateMousUpEvent(input, selectionStart, setSelectionRange) {
   const selectionEnd = selectionStart;
 

--- a/test/types/number_format.spec.tsx
+++ b/test/types/number_format.spec.tsx
@@ -38,6 +38,7 @@ function NumberFormatBaseTest() {
         size="small"
         style={{ color: '#222' }}
       />
+      <NumberFormatBase defaultValue="123" format={(value) => value} />
     </>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1945,13 +1945,13 @@
     defer-to-connect "^1.0.1"
 
 "@testing-library/dom@^8.0.0":
-  version "8.18.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.18.1.tgz#80f91be02bc171fe5a3a7003f88207be31ac2cf3"
-  integrity sha512-oEvsm2B/WtcHKE+IcEeeCqNU/ltFGaVyGbpcm4g/2ytuT49jrlH9x5qRKL/H3A6yfM4YAbSbC0ceT5+9CEXnLg==
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.0.tgz#914aa862cef0f5e89b98cc48e3445c4c921010f6"
+  integrity sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
+    "@types/aria-query" "^5.0.1"
     aria-query "^5.0.0"
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.9"
@@ -1987,10 +1987,10 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@types/aria-query@^4.2.0":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
-  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
+"@types/aria-query@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
+  integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -2161,9 +2161,9 @@
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
 "@types/react-dom@<18.0.0":
-  version "17.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
-  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
+  version "17.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
+  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
   dependencies:
     "@types/react" "^17"
 
@@ -2203,9 +2203,9 @@
     csstype "^3.0.2"
 
 "@types/react@^17":
-  version "17.0.50"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.50.tgz#39abb4f7098f546cfcd6b51207c90c4295ee81fc"
-  integrity sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==
+  version "17.0.59"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.59.tgz#5aa4e161a356fcb824d81f166e01bad9e82243bb"
+  integrity sha512-gSON5zWYIGyoBcycCE75E9+r6dCC2dHdsrVkOEiIYNU5+Q28HcBAuqvDuxHcCbMfHBHdeT5Tva/AFn3rnMKE4g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -6662,9 +6662,9 @@ lunr-languages@^1.4.0:
   integrity sha512-Be5vFuc8NAheOIjviCRms3ZqFFBlzns3u9DXpPSZvALetgnydAN0poV71pVLFn0keYy/s4VblMMkqewTLe+KPg==
 
 lz-string@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
-  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 magic-string@0.25.3:
   version "0.25.3"


### PR DESCRIPTION
- Optimize rendering, and avoid multiple rerender when number format is mounted. 
- Try to guess valueIsNumericString based on props and value, so the user no longer has to define this prop, if the format prop (prefix, suffix, format) doesn't have the number in it.
- Fixes #736 - Fix for focus on mount getting reset.
- Fixed #740 - fixed type for the format, removeFormat, getCaretBoundary.
- Fixed #741 - Thousand and decimal formatting broken while typing when value isNumericString is set to false
- Fixed #742 - cursor position getting changed when format props are updated during typing.
- Fixed #725 - The cursor position not being correct when allowed decimal separator is typed
- Fixed a couple of false positive tests and some regressions around those.
- move caret position test to react/testing-util
