### PR TITLE
fix(number_format_base): prevent warnings in SRR when using useLayoutEffect.

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -229,7 +229,10 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     ? geInputCaretPosition(focusedElm.current)
     : undefined;
 
-  useLayoutEffect(() => {
+  // needed to prevent warning with useLayoutEffect on server
+  const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+  useIsomorphicLayoutEffect(() => {
     const input = focusedElm.current;
     if (formattedValue !== lastUpdatedValue.current.formattedValue && input) {
       const caretPos = getNewCaretPosition(


### PR DESCRIPTION
#### Describe the issue/change
closes: https://github.com/s-yadav/react-number-format/issues/760

#### Add CodeSandbox link to illustrate the issue (If applicable)
See issue for more context

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [ ] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
