### PR TITLE
Type `type` prop as `string`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export type IsCharacterSame = (compareProps: {
 }) => boolean;
 
 type NumberFormatBase = {
-  type?: 'text' | 'tel' | 'password';
+  type?: string;
   displayType?: 'input' | 'text';
   inputMode?: InputAttributes['inputMode'];
   renderText?: (formattedValue: string, otherProps: Partial<NumberFormatBase>) => React.ReactNode;


### PR DESCRIPTION
Fixes #799. Issue text replicated below:
___

#### Describe the issue and the actual behavior

There is a disconnect between the [documentation for the `type` prop](https://s-yadav.github.io/react-number-format/docs/props/#type-string), which states that it accepts any `string`, and the actual TypeScript types, which narrow the accepted values to "text", "tel", or "password":

https://github.com/s-yadav/react-number-format/blob/e2179f9e9d2c4ddd1ab714ff385412b53e9ed3e7/src/types.ts#L68-L69

#### Describe the expected behavior

Since `string` is the correct type for the `type` property of HTML5 `<input>` elements, and browsers fall back to the default behavior of `type="text"` when the type is outside the list of supported values, I believe the `type` prop should be typed as `type?: string`.

In my testing, all `string`s work as expected during runtime.

#### Provide a CodeSandbox link illustrating the issue

https://codesandbox.io/s/type-demo-forked-p4lh8w?file=/src/App.js

#### Provide steps to reproduce this issue

- Use prop `type="number"` in a TypeScript project.

#### Please check the browsers where the issue is seen

_Not specific to a browser; issue is with TypeScript types._