### PR TITLE
Adds event passing to the format function.

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -265,7 +265,7 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
       lastValue: formattedValue,
     };
     let _numAsString = removeFormatting(inputValue, changeMeta);
-    const _formattedValue = _format(_numAsString);
+    const _formattedValue = _format(_numAsString, event);
 
     // formatting can remove some of the number chars, so we need to fine number string again
     _numAsString = removeFormatting(_formattedValue, undefined);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface SourceInfo {
   source: SourceType;
 }
 
-export type FormatInputValueFunction = (inputValue: string) => string;
+export type FormatInputValueFunction = (inputValue: string, event: SyntheticEvent<HTMLInputElement> | null) => string;
 export type RemoveFormattingFunction = (inputValue: string, changeMeta?: ChangeMeta) => string;
 
 export interface SyntheticInputEvent extends React.SyntheticEvent<HTMLInputElement> {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -482,10 +482,10 @@ export function useInternalValues(
         formattedValue = '';
       } else if (typeof value === 'number' || valueIsNumericString) {
         numAsString = typeof value === 'number' ? toNumericString(value) : value;
-        formattedValue = format(numAsString);
+        formattedValue = format(numAsString, null);
       } else {
         numAsString = removeFormatting(value, undefined);
-        formattedValue = format(numAsString);
+        formattedValue = format(numAsString, null);
       }
 
       return { formattedValue, numAsString };


### PR DESCRIPTION
#### Describe the issue/change
  If you set a pattern for a phone number and try autofill, we won't be able to handle the case correctly when the user pastes '10001112233.' Specifically, we would receive '11000111223' in the onChange function instead of '10001112233.' If we don't check the 'isTrusted' property of the event, we may incorrectly process user input when they type '10001112233,' resulting in '1000111223,' which would be correct behavior. However, if you add the removal of extra characters outside the condition, we might end up with '0001112233,' which is not the correct behavior for some countries. For example, consider Kazakhstan, where a phone number can have the format: '7 (7##) ### ##-##.' Removing a potentially extra character could inadvertently remove an essential character in this context.
  This is why I added the passing of the 'event' to the 'format' function, aiming to handle events with 'isTrusted' set to 'false,' as we cannot do this in 'onChange.' In 'onChange,' there is simply no value after autofill; it is already formatted.

#### Example usage (If applicable)
```js
const pattern = '+1 (###) ###-####'

const format = (value, event) => {
  const isTrusted = event ? event.isTrusted : true
  const valueToFormat = value

  // If the event is not 'isTrusted,' we consider it as autofill, and if needed, remove unnecessary characters.
  if (!isTrusted && value.length >10) {
    valueToFormat = value.slice(1)
  }

  return _format(valueToFormat)
}
```
#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [x] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
