### PR TITLE
refactor: clean up `updateValueAndCaretPosition`

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -155,46 +155,33 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
       | React.FocusEvent<HTMLInputElement>
       | React.KeyboardEvent<HTMLInputElement>;
     source: SourceType;
-    caretPos?: number;
-    setCaretPosition?: Boolean;
   }) => {
     const {
       formattedValue: newFormattedValue = '',
       input,
-      setCaretPosition = true,
       source,
       event,
       numAsString,
     } = params;
-    let { caretPos } = params;
+    let caretPos;
 
     if (input) {
-      //calculate caret position if not defined
-      if (caretPos === undefined && setCaretPosition) {
-        const inputValue = params.inputValue || input.value;
+      const inputValue = params.inputValue || input.value;
 
-        const currentCaretPosition = geInputCaretPosition(input);
-
-        /**
-         * set the value imperatively, this is required for IE fix
-         * This is also required as if new caret position is beyond the previous value.
-         * Caret position will not be set correctly
-         */
-        input.value = newFormattedValue;
-
-        //get the caret position
-        caretPos = getNewCaretPosition(inputValue, newFormattedValue, currentCaretPosition);
-      }
+      const currentCaretPosition = geInputCaretPosition(input);
 
       /**
-       * set the value imperatively, as we set the caret position as well imperatively.
-       * This is to keep value and caret position in sync
+       * set the value imperatively, this is required for IE fix
+       * This is also required as if new caret position is beyond the previous value.
+       * Caret position will not be set correctly
        */
       input.value = newFormattedValue;
 
-      //set caret position, and value imperatively when element is provided
-      if (setCaretPosition && caretPos !== undefined) {
-        //set caret position
+      //get the caret position
+      caretPos = getNewCaretPosition(inputValue, newFormattedValue, currentCaretPosition);
+
+      //set caret position imperatively
+      if (caretPos !== undefined) {
         setPatchedCaretPosition(input, caretPos, newFormattedValue);
       }
     }
@@ -287,7 +274,6 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
       inputValue,
       event,
       source,
-      setCaretPosition: true,
       input: event.target as HTMLInputElement,
     });
 


### PR DESCRIPTION
#### Describe the change

- `updateValueAndCaretPosition` is used only once
- its params `setCaretPosition` and `caretPos` were always set to something static
  - `setCaretPosition: true`
  - `caretPos` not passed, hence `undefined`

This PR removes these 2 params; and removes unnecessary checks

**Note:** not sure if these params were used for different purposes in the past, or if they are planned to used differently in the future, but they are not used as of right now, so I'm removing them.
