### PR TITLE
fix: pass currentTarget to onFocus

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -383,6 +383,7 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     if (e.persist) e.persist();
 
     const el = e.target;
+    const currentTarget = e.currentTarget;
     focusedElm.current = el;
 
     timeout.current.focusTimeout = setTimeout(() => {
@@ -398,7 +399,7 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
         setPatchedCaretPosition(el, caretPosition, value);
       }
 
-      onFocus(e);
+      onFocus({ ...e, currentTarget });
     }, 0);
   };
 


### PR DESCRIPTION
#### Describe the issue/change

This change is based on https://stackoverflow.com/a/66086044 `currentTarget`:  only exists if used right from the `onFocus` event; but we get currentTarget **null** because `onFocus(e)` is called **within** a timeout.

References:
- https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget#currenttarget_versus_target
- https://github.com/adobe/react-spectrum/blob/9d8c74a344c9b7539f00fa58d0a02b062b6e830e/packages/%40react-aria/interactions/src/useFocus.ts#L64