### PR TITLE
fix: Optionally chain the `setCaretPosition` element focus

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -235,7 +235,7 @@ export function setCaretPosition(el: HTMLInputElement, caretPos: number) {
     }
 
     // fail city, fortunately this never happens (as far as I've tested) :)
-    el.focus();
+    el.focus?.();
     return false;
   }
 }


### PR DESCRIPTION
#### Describe the issue/change
We are using a custom input component which utilizes increment/decrement buttons to add/subtract a set step to the value. When either button is clicked on the element which is passed to the `setCaretPosition` function does not have a focus function so it errors out (see screenshot below) and therefore never calls the `onValueChange` function with the updated value.

#### Describe the changes proposed/implemented in this PR
Add optional chaining to the focus function call inside the `setCaretPosition` function.

#### Screenshot (If applicable)
![Screen Shot 2023-12-29 at 2 54 00 PM](https://github.com/s-yadav/react-number-format/assets/7826320/8ba43125-4dfe-48f0-b979-c873a169add2)

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [x] Safari (OSX)
- [ ] Safari (iOS)
- [x] Firefox
- [ ] Firefox (Android)
