### PR TITLE
fix: Correct types for customInput property

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -412,7 +412,9 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
   // add input mode on element based on format prop and device once the component is mounted
   const inputMode: InputAttributes['inputMode'] = mounted && addInputMode() ? 'numeric' : undefined;
 
-  const inputProps = Object.assign({ inputMode }, otherProps, {
+  const inputProps: InputAttributes = {
+    inputMode,
+    ...otherProps,
     type,
     value: formattedValue,
     onChange: _onChange,
@@ -420,7 +422,7 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     onMouseUp: _onMouseUp,
     onFocus: _onFocus,
     onBlur: _onBlur,
-  });
+  };
 
   if (displayType === 'text') {
     return renderText ? (
@@ -432,7 +434,6 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     );
   } else if (customInput) {
     const CustomInput = customInput;
-    /* @ts-ignore */
     return <CustomInput {...inputProps} ref={getInputRef} />;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type InputAttributes = Omit<
 type NumberFormatProps<Props, BaseType = InputAttributes> = Props &
   Omit<InputAttributes, keyof BaseType> &
   Omit<BaseType, keyof Props | 'ref'> & {
-    customInput?: React.ComponentType<BaseType>;
+    customInput?: React.ComponentType<React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>>;
   };
 
 export type OnValueChange = (values: NumberFormatValues, sourceInfo: SourceInfo) => void;


### PR DESCRIPTION
#### Describe the issue/change
Any component containing `value` props can not be passed as `customInput` property. Despite the fact that typing prohibits passing the `customInput` with `value`, `number_format_base` passes all props including `value` to `customInput`. 

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR
- fix customInput type
- remove `@ts-ignore` directive

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [ ] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
