### PR TITLE
fix focus wrong field

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -217,7 +217,9 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
 
   useIsomorphicLayoutEffect(() => {
     const input = focusedElm.current;
-    if (formattedValue !== lastUpdatedValue.current.formattedValue && input) {
+    const activeElement = document.activeElement;
+
+    if (input === activeElement && formattedValue !== lastUpdatedValue.current.formattedValue && input) {
       const caretPos = getNewCaretPosition(
         lastUpdatedValue.current.formattedValue,
         formattedValue,


### PR DESCRIPTION
#### Describe the issue/change

When I use react form with react number format
And I'm trying to implement a dynamic calculated field
I have one field that depends on a second field
When I type something in the second field, the cursor jumps from my field in which I write to the field in which I dynamically change the value

I fixed this by checking the currently active element with a focusedElm element to only do setPatchedCaretPosition on the field I'm interacting with


#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
