### PR TITLE
- Fix thousandSeparator missing from documentation

### DIFF
--- a/documentation/v5/docs/numeric_format.md
+++ b/documentation/v5/docs/numeric_format.md
@@ -90,7 +90,7 @@ This allow supporting custom input components with number format.
 import { NumericFormat } from 'react-number-format';
 import { TextField } from '@mui/material';
 
-<NumericFormat value={12323} customInput={TextField} />;
+<NumericFormat value={12323} customInput={TextField} thousandSeparator />;
 ```
 
 <details>

--- a/documentation/v5/docs/props.md
+++ b/documentation/v5/docs/props.md
@@ -15,7 +15,7 @@ This allow supporting custom input components with number format.
 import { NumericFormat } from 'react-number-format';
 import { TextField } from '@mui/material';
 
-<NumericFormat value={12323} customInput={TextField} />;
+<NumericFormat value={12323} customInput={TextField} thousandSeparator/>;
 ```
 
 **Note**: customInput expects reference of component (not a render prop), if you pass an inline component like this `<NumericFormat customInput={() => <TextField />} />`, it will not work.


### PR DESCRIPTION
The documentation is missing the thousandSeparator prop in the custom input, causing confusion.