### PR TITLE
fix: `onValueChange` not called for values with 3 or less characters

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -191,17 +191,14 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
 
   /**
    * if the formatted value is not synced to parent, or if the formatted value is different from last synced value sync it
-   * we also don't need to sync to the parent if no formatting is applied
    * if the formatting props is removed, in which case last formatted value will be different from the numeric string value
    * in such case we need to inform the parent.
    */
   useEffect(() => {
     const { formattedValue: lastFormattedValue, numAsString: lastNumAsString } =
       lastUpdatedValue.current;
-    if (
-      formattedValue !== lastFormattedValue &&
-      (formattedValue !== numAsString || lastFormattedValue !== lastNumAsString)
-    ) {
+
+    if (formattedValue !== lastFormattedValue || numAsString !== lastNumAsString) {
       _onValueChange(getValueObject(formattedValue, numAsString), {
         event: undefined,
         source: SourceType.props,


### PR DESCRIPTION
#### Describe the issue/change
`onValueChange` is not called for values with 3 or less characters.
[The problem is better described in this issue's discussion.](https://github.com/s-yadav/react-number-format/issues/812)

#### Add CodeSandbox link to illustrate the issue (If applicable)
https://codesandbox.io/p/sandbox/numeric-number-format-on-value-change-bug-qrgj2h?file=%2Fsrc%2FApp.tsx

#### Describe specs for failing cases if this is an issue (If applicable)
I have removed one of the tests because it doesn't seem to be very meaningful. In the PR's diffs, I have elaborated it in further detail.

#### Describe the changes proposed/implemented in this PR
This pr aims to fix the issue by simplifying the `useEffect`'s condition which is responsible for ensuring `onValueChange`'s callback is invoked.

#### Link Github issue if this PR solved an existing issue
https://github.com/s-yadav/react-number-format/issues/812

#### Example usage (If applicable)
n/a

#### Screenshot (If applicable)
n/a

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
