### PR TITLE
Fix Number Formatting Order in Customization

### DIFF
--- a/documentation/v5/docs/customization.md
+++ b/documentation/v5/docs/customization.md
@@ -186,16 +186,19 @@ Another example for NumericFormat could be support for custom numerals.
 const persianNumeral = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
 
 function CustomNumeralNumericFormat(props) {
-  const { format, removeFormatting, isCharacterSame, ...rest } = useNumericFormat(props);
+
+   const { format, removeFormatting, isCharacterSame, ...rest } =
+    useNumericFormat(props);
 
   const _format = (val) => {
     const _val = format(val);
+
     return _val.replace(/\d/g, ($1) => persianNumeral[Number($1)]);
   };
 
   const _removeFormatting = (val) => {
-    const _val = val.replace(new RegExp(persianNumeral.join('|'), 'g'), ($1) =>
-      persianNumeral.indexOf($1),
+    const _val = val.replace(new RegExp(persianNumeral.join("|"), "g"), ($1) =>
+      persianNumeral.indexOf($1)
     );
 
     return removeFormatting(_val);
@@ -203,13 +206,18 @@ function CustomNumeralNumericFormat(props) {
 
   const _isCharacterSame = (compareMeta) => {
     const isCharSame = isCharacterSame(compareMeta);
-    const { formattedValue, currentValue, formattedValueIndex, currentValueIndex } = compareMeta;
+    const {
+      formattedValue,
+      currentValue,
+      formattedValueIndex,
+      currentValueIndex,
+    } = compareMeta;
     const curChar = currentValue[currentValueIndex];
     const newChar = formattedValue[formattedValueIndex];
     const curPersianChar = persianNumeral[Number(curChar)] ?? curChar;
     const newPersianChar = persianNumeral[Number(newChar)] ?? newChar;
 
-    return isCharSame || curPersianChar || newPersianChar;
+    return isCharSame || curPersianChar === newPersianChar;
   };
 
   return (

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -10,30 +10,37 @@ import { cardExpiry } from '../../custom_formatters/card_expiry';
 const persianNumeral = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
 
 function CustomNumeralNumericFormat(props) {
-  const { format, removeFormatting, isCharacterSame, ...rest } = useNumericFormat(props);
+  const { format, removeFormatting, isCharacterSame, ...rest } =
+    useNumericFormat(props);
 
   const _format = (val) => {
     const _val = format(val);
+
     return _val.replace(/\d/g, ($1) => persianNumeral[Number($1)]);
   };
 
-  const _removeFormatting = (val, ...rest) => {
-    const _val = val.replace(new RegExp(persianNumeral.join('|'), 'g'), ($1) =>
-      persianNumeral.indexOf($1),
+  const _removeFormatting = (val) => {
+    const _val = val.replace(new RegExp(persianNumeral.join("|"), "g"), ($1) =>
+      persianNumeral.indexOf($1)
     );
 
-    return removeFormatting(_val, ...rest);
+    return removeFormatting(_val);
   };
 
   const _isCharacterSame = (compareMeta) => {
     const isCharSame = isCharacterSame(compareMeta);
-    const { formattedValue, currentValue, formattedValueIndex, currentValueIndex } = compareMeta;
+    const {
+      formattedValue,
+      currentValue,
+      formattedValueIndex,
+      currentValueIndex,
+    } = compareMeta;
     const curChar = currentValue[currentValueIndex];
     const newChar = formattedValue[formattedValueIndex];
     const curPersianChar = persianNumeral[Number(curChar)] ?? curChar;
     const newPersianChar = persianNumeral[Number(newChar)] ?? newChar;
 
-    return isCharSame || curPersianChar || newPersianChar;
+    return isCharSame || curPersianChar === newPersianChar;
   };
 
   return (


### PR DESCRIPTION
#### Describe the issue/change

Problem: When typing Persian numbers from 1 to 9, there is an issue with how the numbers are displayed. Currently, the numbers appear in an incorrect order or format. For example, if you type a sequence of numbers like ۱۲۳,۴۵۶,۷۸۹  it appears as ۱۲۳,۵۶۸,۹۷۴.

https://github.com/user-attachments/assets/a0c7d9ed-aa50-4bb4-ba00-90292903911e



Expected Behavior: After the fix, when typing Persian numbers from 1 to 9, they should be displayed in the correct order and format, like ۱۲۳,۴۵۶,۷۸۹.


https://github.com/user-attachments/assets/86047fc6-0a31-4cf2-9e7f-c29b84c91810



#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [x] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
