### PR TITLE
Fix the keyboard being displayed on the ios system

### DIFF
--- a/src/number_format_base.tsx
+++ b/src/number_format_base.tsx
@@ -154,9 +154,9 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     inputValue?: string;
     input?: HTMLInputElement | null;
     event?:
-      | React.ChangeEvent<HTMLInputElement>
-      | React.FocusEvent<HTMLInputElement>
-      | React.KeyboardEvent<HTMLInputElement>;
+    | React.ChangeEvent<HTMLInputElement>
+    | React.FocusEvent<HTMLInputElement>
+    | React.KeyboardEvent<HTMLInputElement>;
     source: SourceType;
   }) => {
     const { formattedValue: newFormattedValue = '', input, source, event, numAsString } = params;
@@ -432,6 +432,7 @@ export default function NumberFormatBase<BaseType = InputAttributes>(
     onMouseUp: _onMouseUp,
     onFocus: _onFocus,
     onBlur: _onBlur,
+    pattern: /[^0-9,.]/,
   });
 
   if (displayType === 'text') {

--- a/src/numeric_format.tsx
+++ b/src/numeric_format.tsx
@@ -561,6 +561,7 @@ export function useNumericFormat<BaseType = InputAttributes>(
     getCaretBoundary: (formattedValue: string) => getCaretBoundary(formattedValue, props),
     onKeyDown: _onKeyDown,
     onBlur: _onBlur,
+    pattern: /[^0-9,.]/,
   };
 }
 


### PR DESCRIPTION
#### Fixed the keyboard being displayed on the ios

#### The proposed change is to pass as the pattern property only for the number format the regex that allows the keyboard to be correct for ios

#### [Link for the Github issue](https://github.com/s-yadav/react-number-format/issues/189)

#### Please check which browsers were used for testing
- [ ✔] Chrome
- [ ✔] Chrome (Android)
- [ ✔] Safari (OSX)
- [ ✔] Safari (iOS)
- [ ✔] Firefox
- [ ✔] Firefox (Android)
