### PR TITLE
fix: add explicit return types

### DIFF
--- a/src/numeric_format.tsx
+++ b/src/numeric_format.tsx
@@ -566,7 +566,7 @@ export function useNumericFormat<BaseType = InputAttributes>(
 
 export default function NumericFormat<BaseType = InputAttributes>(
   props: NumericFormatProps<BaseType>,
-) {
+): React.ReactElement {
   const numericFormatProps = useNumericFormat(props);
 
   return <NumberFormatBase {...numericFormatProps} />;

--- a/src/pattern_format.tsx
+++ b/src/pattern_format.tsx
@@ -265,7 +265,7 @@ export function usePatternFormat<BaseType = InputAttributes>(
 
 export default function PatternFormat<BaseType = InputAttributes>(
   props: PatternFormatProps<BaseType>,
-) {
+): React.ReactElement {
   const patternFormatProps = usePatternFormat(props);
 
   return <NumberFormatBase {...patternFormatProps} />;


### PR DESCRIPTION
#### Describe the issue/change

The return type of `NumericFormat` and `PatternFormat` was being inferred as `JSX.Element` which caused the following type errors (`typescript` `v5.7.3` and `@types/react` `v19.0.4`):

```
[redacted] - error TS2786: 'NumericFormat' cannot be used as a JSX component.
  Its type '<BaseType = InputAttributes>(props: NumericFormatProps<BaseType>) => Element' is not a valid JSX element type.
    Type '<BaseType = InputAttributes>(props: NumericFormatProps<BaseType>) => Element' is not assignable to type '(props: any) => ReactNode | Promise<ReactNode>'.
      Type 'Element' is not assignable to type 'ReactNode | Promise<ReactNode>'.
        Property 'children' is missing in type 'Element' but required in type 'ReactPortal'.

58             <NumericFormat
                ~~~~~~~~~~~~~

  node_modules/@types/react/index.d.ts:387:9
    387         children: ReactNode;
                ~~~~~~~~
    'children' is declared here.
```

and

```
[redacted] - error TS2786: 'PatternFormat' cannot be used as a JSX component.
  Its type '<BaseType = InputAttributes>(props: PatternFormatProps<BaseType>) => Element' is not a valid JSX element type.
    Type '<BaseType = InputAttributes>(props: PatternFormatProps<BaseType>) => Element' is not assignable to type '(props: any) => ReactNode | Promise<ReactNode>'.
      Type 'Element' is not assignable to type 'ReactNode | Promise<ReactNode>'.
        Property 'children' is missing in type 'Element' but required in type 'ReactPortal'.

64         <PatternFormat
            ~~~~~~~~~~~~~

  node_modules/@types/react/index.d.ts:387:9
    387         children: ReactNode;
                ~~~~~~~~
    'children' is declared here.
```


#### Add CodeSandbox link to illustrate the issue (If applicable)

Sample code that has an issue:

```tsx
const SomeWrappingComponent = ({component}: {component: React.ReactElement}) => component

const App = () => {
  return <SomeWrappingComponent component={<NumericFormat />} />
}
```

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

Instead of being inferred, explicitly add the return type of `React.ReactElement` which represents a JSX element.

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

#### Screenshot (If applicable)
<img width="1226" alt="Screenshot 2025-01-12 at 6 10 35 PM" src="https://github.com/user-attachments/assets/51ecfdfd-8d5c-4f34-86fb-e9d2ae94283d" />

#### Please check which browsers were used for testing
- [ ] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
