### PR TITLE
feat: export SourceType enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export type {
   NumberFormatBaseProps,
   PatternFormatProps,
   SourceInfo,
+  SourceType,
   NumberFormatValues,
   OnValueChange,
   InputAttributes,


### PR DESCRIPTION
#### Describe the issue/change

Gives consumers of this library a way to properly avoid triggering the eslint rule `@typescript-eslint/no-unsafe-enum-comparison`.

#### Add CodeSandbox link to illustrate the issue (If applicable)

#### Describe specs for failing cases if this is an issue (If applicable)

#### Describe the changes proposed/implemented in this PR

Add export.

#### Link Github issue if this PR solved an existing issue

#### Example usage (If applicable)

import { SourceType } from "react-number-format";

```tsx
onValueChange={(values, sourceInfo) => {
  if (sourceInfo.source === SourceType.event) {
    // do something
  }
}}
```

#### Screenshot (If applicable)

#### Please check which browsers were used for testing
- [ ] Chrome
- [ ] Chrome (Android)
- [ ] Safari (OSX)
- [ ] Safari (iOS)
- [ ] Firefox
- [ ] Firefox (Android)
